### PR TITLE
Carry out mapping using the NCI Metathesaurus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
+# Ignore the META directory containing UMLS RRF files.
+/META
+
+# Scala output files
 *.class
 *.log
+
+# sbt specific
+.cache/
+.history/
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore the META directory containing UMLS RRF files.
 /META
 
+# Ignore the SQLite database we use to do some backend stuff.
+./sqlite.db
+
 # Scala output files
 *.class
 *.log

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+rules = [
+    ExplicitResultTypes,
+    NoAutoTupling,
+    RemoveUnused,
+    DisableSyntax,
+    LeakingImplicitClassVal,
+    NoValInForComprehension,
+    ProcedureSyntax
+]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,4 @@
+version = "2.2.2"
+style = IntelliJ
+maxColumn = 100
+align = more

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
 version = "2.2.2"
 style = IntelliJ
 maxColumn = 100
-align = more
+align = some

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # umls-rrf-scala
 A very basic library for parsing files in the UMLS RRF format
+
+## How to use
+This program expects the `META` directory from the
+[NLM UMLS download](https://www.nlm.nih.gov/research/umls/index.html)
+to be in the directory where the program is executed. The `--rrf-dir`
+command line argument can also be used to point to the `META` directory
+in another directory.
+
+```console
+$ sbt "run --from-source SNOMEDCT_US --to-source NCI -o mappings.txt"
+[info] Loading settings for project global-plugins from metals.sbt ...
+[info] Loading global plugins from /Users/gaurav/.sbt/1.0/plugins
+[info] Loading settings for project umls-rrf-scala-build from plugins.sbt ...
+[info] Loading project definition from /Users/gaurav/Development/umls-rrf-scala/project
+[info] Loading settings for project umls-rrf-scala from build.sbt ...
+[info] Set current project to umls-rrf (in build file:/Users/gaurav/Development/umls-rrf-scala/)
+[info] Compiling 1 Scala source to /Users/gaurav/Development/umls-rrf-scala/target/scala-2.13/classes ...
+[info] running (fork) org.renci.umls.CodeMapper --from-source SNOMEDCT_US --to-source NCI -o mappings.txt
+[info] 15:32:38.794 [main] INFO  org.renci.umls.CodeMapper$ - Loaded directory for release: # Release Metadata
+[info] #Tue Oct 02 03:11:52 EDT 2018
+[info] umls.release.date=20180801
+[info] umls.release.name=201808
+[info] mmsys.build.date=2018_09_17_23_18_10
+[info] mmsys.version=MMSYS-2016AA-20160329
+[info] nlm.build.date=2018_10_01_14_48_01
+[info] umls.release.description=Base Release for 201808
+[info] 15:32:38.802 [main] INFO  org.renci.umls.CodeMapper$ - Using SQLite backend: org.apache.commons.dbcp2.DriverManagerConnectionFactory@434a63ab
+[info] 15:32:43.298 [main] INFO  org.renci.umls.db.DbConcepts - Concept table MRCONSO_bda810d0c047e368385a441642703331581153cd7fe728fdc256a3e3960f1c40 has 6857637 rows.
+[info] 15:32:43.725 [main] INFO  org.renci.umls.db.DbConcepts - Loading halfmaps for SNOMEDCT_US
+[info] 15:32:44.930 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 100000 halfmaps.
+[info] 15:32:45.664 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 200000 halfmaps.
+[info] 15:32:46.638 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 300000 halfmaps.
+[info] 15:32:47.398 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 400000 halfmaps.
+[info] 15:32:48.055 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 500000 halfmaps.
+[info] 15:32:49.106 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 600000 halfmaps.
+[info] 15:32:49.803 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 700000 halfmaps.
+[info] 15:32:51.134 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 800000 halfmaps.
+[info] 15:32:51.602 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 900000 halfmaps.
+[info] 15:32:51.742 [main] INFO  org.renci.umls.db.DbConcepts - 914827 halfmaps loaded.
+[info] 15:32:51.748 [main] INFO  org.renci.umls.db.DbConcepts - Loading halfmaps for NCI
+[info] 15:32:53.637 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 100000 halfmaps.
+[info] 15:32:54.506 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 200000 halfmaps.
+[info] 15:32:55.204 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 300000 halfmaps.
+[info] 15:32:55.473 [main] INFO  org.renci.umls.db.DbConcepts - 343103 halfmaps loaded.
+[success] Total time: 26 s, completed Apr 15, 2020, 3:32:58 PM
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // Publication information
-name := "umls-rrf"
-ThisBuild / organization := "com.ggvaidya"
-ThisBuild / version      := "0.1-SNAPSHOT"
+name         := "umls-rrf"
+organization := "com.ggvaidya"
+version      := "0.1-SNAPSHOT"
 
 // Code license
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,55 @@
+// Publication information
+name := "umls-rrf"
+ThisBuild / organization := "com.ggvaidya"
+ThisBuild / version      := "0.1-SNAPSHOT"
+
+// Code license
+licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
+
+// Scalac options.
+scalaVersion := "2.13.1"
+scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Ywarn-unused")
+
+addCompilerPlugin(scalafixSemanticdb)
+scalacOptions in Test ++= Seq("-Yrangepos")
+
+// Set up the main class.
+mainClass in (Compile, run) := Some("org.renci.umls.CodeMapper")
+
+// Fork when running.
+fork in run := true
+
+// Set up testing.
+testFrameworks += new TestFramework("utest.runner.Framework")
+
+// Code formatting and linting tools.
+wartremoverWarnings ++= Warts.unsafe
+
+addCommandAlias(
+  "scalafixCheckAll",
+  "; compile:scalafix --check ; test:scalafix --check"
+)
+
+// Library dependencies.
+libraryDependencies ++= {
+  Seq(
+    // Logging
+    "com.typesafe.scala-logging"  %% "scala-logging"          % "3.9.2",
+    "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
+
+    // Command line argument parsing.
+    "org.rogach"                  %% "scallop"                % "3.3.2",
+
+    // Import Apache Jena to read JSON-LD.
+    // "org.apache.jena"             % "jena-core"               % "3.14.0",
+
+    // https://mvnrepository.com/artifact/org.apache.jena/jena-arq
+    // "org.apache.jena"             % "jena-arq"                % "3.14.0",
+
+    // Add support for CSV
+    "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
+
+    // Testing
+    "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
+  )
+}

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,12 @@ libraryDependencies ++= {
     // Add support for CSV
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
 
+    // Add support for JDBC via Slick
+    "com.typesafe.slick"          %% "slick"                  % "3.3.2",
+
+    // Add support for SQLite via JDBC
+    "org.xerial"                  % "sqlite-jdbc"             % "3.30.1",
+
     // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,11 @@ libraryDependencies ++= {
     // Add support for calculating hashes for files.
     "commons-codec"               % "commons-codec"           % "1.14",
 
+    // Add methods for storing information in-memory.
+    "com.github.cb372"            %% "scalacache-core"        % "0.28.0",
+    "com.github.cb372"            %% "scalacache-caffeine"    % "0.28.0",
+    "com.github.ben-manes.caffeine" % "caffeine"              % "2.8.1",
+
   // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -49,13 +49,16 @@ libraryDependencies ++= {
     // Add support for CSV
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
 
-    // Add support for JDBC via Slick
-    "com.typesafe.slick"          %% "slick"                  % "3.3.2",
+    // We need JDBC connection pooling so we can start new connections as needed.
+    "org.apache.commons"          % "commons-dbcp2"           % "2.7.0",
 
-    // Add support for SQLite via JDBC
+  // Add support for SQLite via JDBC
     "org.xerial"                  % "sqlite-jdbc"             % "3.30.1",
 
-    // Testing
+    // Add support for calculating hashes for files.
+    "commons-codec"               % "commons-codec"           % "1.14",
+
+  // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+// Code formatting and linting tools.
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -1,7 +1,6 @@
 package org.renci.umls
 
 import java.io.File
-import java.io.File
 
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
@@ -46,7 +45,7 @@ object CodeMapper extends App with LazyLogging {
   // Read RRF directory.
   val rrfDir = new RRFDir(conf.rrfDir(), conf.sqliteDb())
   logger.info(s"Loaded directory for release: ${rrfDir.releaseInfo}")
-  logger.info(s"Loaded SQLite as database backend: ${rrfDir.sqliteDB}")
+  logger.info(s"Using SQLite backend: ${rrfDir.sqliteDb}")
 
   // rrfDir.concepts.concepts.foreach(concept => logger.info(" - Concept: " + concept))
 }

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -87,8 +87,16 @@ object CodeMapper extends App with LazyLogging {
 
     // Both sourceFrom and sourceTo are set!
     if (conf.idFile.isEmpty) {
-      val map = concepts.getMap(conf.fromSource(), Seq.empty, conf.toSource(), Seq.empty)
-      map.foreach(stream.println(_))
+      val maps = concepts.getMap(conf.fromSource(), Seq.empty, conf.toSource(), Seq.empty)
+      stream.println("fromSource\tfromCode\ttoSource\ttoCode\tnciMTConceptIds\tlabels")
+      maps.foreach(map => {
+        stream.println(
+          s"${map.fromSource}\t${map.fromCode}\t" +
+          s"${map.toSource}\t${map.toCode}\t" +
+          s"${map.conceptIds.mkString(", ")}\t" +
+          s"${map.labels}"
+        )
+      })
     } else {
       val ids = Source.fromFile(conf.idFile()).getLines.map(_.trim).toSeq
       logger.info(s"Filtering to ${ids.size} IDs from ${conf.idFile()}.")

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -101,11 +101,13 @@ object CodeMapper extends App with LazyLogging {
       val matched = ids.map(id => {
         val maps = mapByFromId.getOrElse(id, Seq())
         val parentAtomIds = rrfDir.hierarchy.getParents(maps.flatMap(_.atomIds))
+        val parentCUIs = concepts.getCUIsForAUI(parentAtomIds.toSeq)
+        val halfMaps = concepts.getHalfMaps(conf.toSource(), parentCUIs.toSeq)
         stream.println(
           s"$id\t${maps.size}"
             + s"\t${maps.map(m => m.toSource + ":" + m.toCode)}"
             + s"\t${maps.map(_.labels).mkString("|")}"
-            + s"\t${parentAtomIds}"
+            + s"\t${halfMaps}"
         )
         maps
       }).filter(_.nonEmpty)

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -32,6 +32,11 @@ object CodeMapper extends App with LazyLogging {
       default = Some(new File("./META"))
     )
 
+    val sqliteDb: ScallopOption[File] = opt[File](
+      descr = "SQLite file used as a backend database",
+      default = Some(new File("./sqlite.db"))
+    )
+
     verify()
   }
 
@@ -39,8 +44,9 @@ object CodeMapper extends App with LazyLogging {
   val conf = new Conf(args.toIndexedSeq, logger)
 
   // Read RRF directory.
-  val rrfDir = new RRFDir(conf.rrfDir())
-  logger.info("Loaded directory for release: " + rrfDir.releaseInfo)
+  val rrfDir = new RRFDir(conf.rrfDir(), conf.sqliteDb())
+  logger.info(s"Loaded directory for release: ${rrfDir.releaseInfo}")
+  logger.info(s"Loaded SQLite as database backend: ${rrfDir.sqliteDB}")
 
-  rrfDir.concepts.concepts.foreach(concept => logger.info(" - Concept: " + concept))
+  // rrfDir.concepts.concepts.foreach(concept => logger.info(" - Concept: " + concept))
 }

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -42,5 +42,5 @@ object CodeMapper extends App with LazyLogging {
   val rrfDir = new RRFDir(conf.rrfDir())
   logger.info("Loaded directory for release: " + rrfDir.releaseInfo)
 
-  rrfDir.cols.asColumns.foreach(col => logger.info(" - Column: " + col))
+  rrfDir.concepts.concepts.foreach(concept => logger.info(" - Concept: " + concept))
 }

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -1,0 +1,44 @@
+package org.renci.umls
+
+import java.io.File
+import java.io.File
+
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.renci.umls.rrf.RRFDir
+
+/**
+  * Map terms from one code system to another.
+  */
+object CodeMapper extends App with LazyLogging {
+  /**
+    * Command line configuration for CodeMapper.
+    */
+  class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments) {
+    override def onError(e: Throwable): Unit = e match {
+      case ScallopException(message) =>
+        printHelp
+        logger.error(message)
+        System.exit(1)
+      case ex => super.onError(ex)
+    }
+
+    val version = getClass.getPackage.getImplementationVersion
+    version(s"CodeMapper: map from one source to another (v$version)")
+
+    val rrfDir: ScallopOption[File] = opt[File](
+      descr = "Directory of RRF files (called 'META' in the UMLS download)",
+      default = Some(new File("./META"))
+    )
+
+    verify()
+  }
+
+  // Parse command line arguments.
+  val conf = new Conf(args.toIndexedSeq, logger)
+
+  // Read RRF directory.
+  val rrfDir = new RRFDir(conf.rrfDir())
+  logger.info("Loaded directory for release: " + rrfDir.releaseInfo)
+}

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -94,7 +94,7 @@ object CodeMapper extends App with LazyLogging {
       logger.info(s"Filtering to ${ids.size} IDs from ${conf.idFile()}.")
 
       val map = concepts.getMap(conf.fromSource(), ids, conf.toSource(), Seq.empty)
-      val allTermCuis = concepts.getCUIsForSCUIs(conf.fromSource(), ids)
+      val allTermCuis = concepts.getCUIsForCodes(conf.fromSource(), ids)
 
       stream.println("id\tcount\tterm\tlabels\tparentTerms\tparentLabels")
 

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -1,6 +1,6 @@
 package org.renci.umls
 
-import java.io.{File, FileOutputStream, FileWriter, PrintStream}
+import java.io.{File, FileOutputStream, PrintStream}
 
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -41,4 +41,6 @@ object CodeMapper extends App with LazyLogging {
   // Read RRF directory.
   val rrfDir = new RRFDir(conf.rrfDir())
   logger.info("Loaded directory for release: " + rrfDir.releaseInfo)
+
+  rrfDir.cols.asColumns.foreach(col => logger.info(" - Column: " + col))
 }

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -36,6 +36,14 @@ object CodeMapper extends App with LazyLogging {
       default = Some(new File("./sqlite.db"))
     )
 
+    val fromSource: ScallopOption[String] = opt[String](
+      descr = "The source to translate from"
+    )
+
+    val toSource: ScallopOption[String] = opt[String](
+      descr = "The source to translate to"
+    )
+
     verify()
   }
 
@@ -47,5 +55,23 @@ object CodeMapper extends App with LazyLogging {
   logger.info(s"Loaded directory for release: ${rrfDir.releaseInfo}")
   logger.info(s"Using SQLite backend: ${rrfDir.sqliteDb}")
 
-  // rrfDir.concepts.concepts.foreach(concept => logger.info(" - Concept: " + concept))
+  val concepts = rrfDir.concepts
+  val sources = concepts.getSources
+
+  if (conf.fromSource.isEmpty && conf.toSource.isEmpty) {
+    logger.info("Sources:")
+    sources.map(entry => {
+      logger.info(s" - ${entry._1} (${entry._2} entries)")
+    })
+  } else if (conf.fromSource.isEmpty) {
+    // We know sourceTo is set.
+    logger.error(s"--source-from is empty, although --source-to is set to '${conf.toSource()}'")
+  } else if (conf.toSource.isEmpty) {
+    // We know sourceFrom is set.
+    logger.error(s"--source-to is empty, although --source-from is set to '${conf.fromSource()}'")
+  } else {
+    // Both sourceFrom and sourceTo are set!
+    val map = concepts.getMap(conf.fromSource(), conf.toSource())
+    map.foreach(println(_))
+  }
 }

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -95,12 +95,18 @@ object CodeMapper extends App with LazyLogging {
 
       val map = concepts.getMap(conf.fromSource(), ids, conf.toSource(), Seq.empty)
 
-      stream.println("id\tcount\tterm\tlabels")
+      stream.println("id\tcount\tterm\tlabels\tparentTerms\tparentLabels")
 
       val mapByFromId = map.groupBy(_.fromCode)
       val matched = ids.map(id => {
         val maps = mapByFromId.getOrElse(id, Seq())
-        stream.println(s"$id\t${maps.size}\t${maps.map(m => m.toSource + ":" + m.toCode)}\t${maps.map(_.labels).mkString("|")}")
+        val parentAtomIds = rrfDir.hierarchy.getParents(maps.flatMap(_.atomIds))
+        stream.println(
+          s"$id\t${maps.size}"
+            + s"\t${maps.map(m => m.toSource + ":" + m.toCode)}"
+            + s"\t${maps.map(_.labels).mkString("|")}"
+            + s"\t${parentAtomIds}"
+        )
         maps
       }).filter(_.nonEmpty)
 

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -101,16 +101,17 @@ object CodeMapper extends App with LazyLogging {
       val ids = Source.fromFile(conf.idFile()).getLines.map(_.trim).toSeq
       logger.info(s"Filtering to ${ids.size} IDs from ${conf.idFile()}.")
 
+      val halfMapByCode = concepts.getHalfMapsForCodes(conf.fromSource(), ids).groupBy(_.code)
       val map = concepts.getMap(conf.fromSource(), ids, conf.toSource(), Seq.empty)
       val allTermCuis = concepts.getCUIsForCodes(conf.fromSource(), ids)
 
-      stream.println("id\tcount\tterm\tlabels\tparentTerms\tparentLabels")
+      stream.println("fromSource\tid\tlabels\tcountDirect\tcountViaParent\ttoIds\ttoLabels\tncimtIds\tparentSource\tparentIds\tparentLabels")
 
       var count = 0
       val mapByFromId = map.groupBy(_.fromCode)
       val matched = ids.map(id => {
         val maps = mapByFromId.getOrElse(id, Seq())
-        val (parentStr, halfMaps) = if (maps.nonEmpty) ("", Map.empty) else {
+        val (parentStr, halfMaps) = if (maps.nonEmpty) ("", Seq.empty) else {
           val termCuis = allTermCuis.getOrElse(id, Seq.empty)
           // logger.info(s"Checking $termCuis for parent AUI information.")
 
@@ -124,13 +125,13 @@ object CodeMapper extends App with LazyLogging {
           val codes = halfMaps.map(_.code).toSet
           val labels = halfMaps.map(_.label).toSet
 
-          (s"\t$cuis\t$sources\t$codes\t$labels", halfMaps)
+          (s"\t${cuis.mkString("|")}\t${sources.mkString("|")}\t${codes.mkString("|")}\t${labels.mkString("|")}", halfMaps)
         }
 
         stream.println(
-          s"$id\t${maps.size}\t${halfMaps.size}\t"
-            + s"\t${maps.map(m => m.toSource + ":" + m.toCode)}"
-            + s"\t${maps.map(_.labels).mkString("|")}"
+          s"${conf.fromSource()}\t$id\t${halfMapByCode.getOrElse(id, Seq()).map(_.label).mkString("|")}\t${maps.size}\t${halfMaps.size}"
+            + s"\t${maps.map(m => m.toSource + ":" + m.toCode).mkString("|")}"
+            + s"\t${maps.map(_.labels.mkString(";")).mkString("|")}"
             + s"$parentStr"
         )
 
@@ -145,14 +146,14 @@ object CodeMapper extends App with LazyLogging {
 
       val matchedTerm = matched.filter(_._1.nonEmpty).flatMap(_._1)
       val matchedParent = matched.filter(_._2.nonEmpty).flatMap(_._2)
-      val matchedTotal = matchedTerm.size + matchedParent.size
+      val matchedTotal = matched.filter(m => m._1.nonEmpty || m._2.nonEmpty)
 
       val percentageTerm = (matchedTerm.size.toFloat/ids.size) * 100
       val percentageParent = (matchedParent.size.toFloat/ids.size) * 100
-      val percentageTotal = (matchedTotal.toFloat/ids.size) * 100
+      val percentageTotal = (matchedTotal.size.toFloat/ids.size) * 100
       logger.info(f"Matched ${matchedTerm.size} IDs out of ${ids.size} ($percentageTerm%.2f%%)")
       logger.info(f"Matched a further ${matchedParent.size} IDs via the parent term ($percentageParent%.2f%%)")
-      logger.info(f"Total coverage: $matchedTotal IDs out of ${ids.size} ($percentageTotal%.2f%%)")
+      logger.info(f"Total coverage: ${matchedTotal.size} IDs out of ${ids.size} ($percentageTotal%.2f%%)")
     }
 
     stream.close()

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -94,7 +94,7 @@ object CodeMapper extends App with LazyLogging {
           s"${map.fromSource}\t${map.fromCode}\t" +
           s"${map.toSource}\t${map.toCode}\t" +
           s"${map.conceptIds.mkString(", ")}\t" +
-          s"${map.labels}"
+          s"${map.labels.mkString("|")}"
         )
       })
     } else {

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -1,17 +1,105 @@
 package org.renci.umls.db
 
 import java.io.File
+import java.sql.{Connection, PreparedStatement}
 
-import slick.jdbc.SQLiteProfile.backend.DatabaseDef
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.apache.commons.dbcp2.ConnectionFactory
 
+import scala.util.Try
 import org.renci.umls.rrf._
 
-/** A wrapper for RRFConcepts that uses  */
-class DbConcepts(db: DatabaseDef, file: File, filename: String) extends RRFConcepts(file, filename) {
+import scala.io.Source
 
+/** A wrapper for RRFConcepts that uses  */
+class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RRFConcepts(file, filename) with LazyLogging {
+  val tableName: String = "MRCONSO_" + sha256
+
+  val conn1 = db.createConnection()
+  val checkCount = conn1.createStatement()
+  val results = Try { checkCount.executeQuery(s"SELECT COUNT(*) AS cnt FROM $tableName") }
+  val rowsFromDb = if (results.isSuccess) results.get.getInt(1) else -1
+  conn1.close()
+
+  if (rowsFromDb > 0 && rowsFromDb == rowCount) {
+    logger.info(s"Concept table $tableName has $rowsFromDb rows.")
+  } else {
+    logger.info(s"Concept table $tableName is not present or is out of sync. Regenerating.")
+
+    val conn = db.createConnection()
+    val regenerate = conn.createStatement()
+    regenerate.execute(s"DROP TABLE IF EXISTS $tableName")
+    regenerate.execute(s"""CREATE TABLE $tableName (
+      |CUI TEXT,
+      |LAT TEXT,
+      |TS TEXT,
+      |LUI TEXT,
+      |STT TEXT,
+      |SUI TEXT,
+      |ISPREF TEXT,
+      |AUI TEXT,
+      |SAUI TEXT,
+      |SCUI TEXT,
+      |SDUI TEXT,
+      |SAB TEXT,
+      |TTY TEXT,
+      |CODE TEXT,
+      |STR TEXT,
+      |SRL TEXT,
+      |SUPPRESS TEXT,
+      |CVF TEXT
+      )""".stripMargin)
+
+    val insertStmt = conn.prepareStatement(
+      s"INSERT INTO $tableName (CUI, LAT, TS, LUI, STT, SUI, ISPREF, AUI, SAUI, SCUI, SDUI, SAB, TTY, CODE, STR, SRL, SUPPRESS, CVF) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+
+    var count = 0
+    Source.fromFile(file).getLines.map(_.split("\\|", -1).toIndexedSeq) foreach { row =>
+      insertStmt.clearParameters()
+
+      (1 until 19) foreach ({ index =>
+        insertStmt.setString(index, row(index - 1))
+      })
+      insertStmt.addBatch()
+
+      count += 1
+      if (count % 100000 == 0) {
+        val percentage = count.toFloat/rowCount*100
+        logger.info(f"Batched $count rows out of $rowCount ($percentage%.2f%%), executing.")
+        insertStmt.executeBatch()
+        insertStmt.clearBatch()
+      }
+    }
+    insertStmt.executeBatch()
+    conn.close()
+  }
 }
+
+/** Represents a single column entry. */
+case class Concept(
+                    ConceptID: String,            // CUI
+                    Lang: String,                 // LAT
+                    TermStatus: String,           // TS
+                    TermID: String,               // LUI
+                    StringType: String,           // STT
+                    StringID: String,             // SUI
+                    IsPreferred: Boolean,         // ISPREF
+                    AtomID: String,               // AUI
+                    SourceAtomID: String,         // SAUI
+                    SourceConceptID: String,      // SCUI
+                    SourceDescriptorID: String,   // SDUI
+                    Source: String,               // SAB
+                    TermType: String,             // TTY
+                    SourceEntryID: String,        // CODE
+                    EntryString: String,          // STR
+                    SourceRestriction: String,    // SRL
+                    SuppressibleFlag: String,     // SUPPRESS
+                    ContentViewFlag: String       // CVF
+                  )
 
 object DbConcepts {
   /** Wrap an RRF file using a database to cache results. */
-  def fromDatabase(db: DatabaseDef, rrfFile: RRFFile) = new DbConcepts(db, rrfFile.file, rrfFile.filename)
+  def fromDatabase(db: ConnectionFactory, rrfFile: RRFFile) = new DbConcepts(db, rrfFile.file, rrfFile.filename)
 }

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -1,0 +1,17 @@
+package org.renci.umls.db
+
+import java.io.File
+
+import slick.jdbc.SQLiteProfile.backend.DatabaseDef
+
+import org.renci.umls.rrf._
+
+/** A wrapper for RRFConcepts that uses  */
+class DbConcepts(db: DatabaseDef, file: File, filename: String) extends RRFConcepts(file, filename) {
+
+}
+
+object DbConcepts {
+  /** Wrap an RRF file using a database to cache results. */
+  def fromDatabase(db: DatabaseDef, rrfFile: RRFFile) = new DbConcepts(db, rrfFile.file, rrfFile.filename)
+}

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -29,7 +29,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RR
   val conn1 = db.createConnection()
   val checkCount = conn1.createStatement()
   val results = Try { checkCount.executeQuery(s"SELECT COUNT(*) AS cnt FROM $tableName") }
-  val rowsFromDb = if (results.isSuccess) results.get.getInt(1) else -1
+  val rowsFromDb = results.map(_.getInt(1)).getOrElse(-1)
   conn1.close()
 
   if (rowsFromDb > 0 && rowsFromDb == rowCount) {

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -316,28 +316,6 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RR
   }
 }
 
-/** Represents a single column entry. */
-case class Concept(
-                    ConceptID: String,            // CUI
-                    Lang: String,                 // LAT
-                    TermStatus: String,           // TS
-                    TermID: String,               // LUI
-                    StringType: String,           // STT
-                    StringID: String,             // SUI
-                    IsPreferred: Boolean,         // ISPREF
-                    AtomID: String,               // AUI
-                    SourceAtomID: String,         // SAUI
-                    SourceConceptID: String,      // SCUI
-                    SourceDescriptorID: String,   // SDUI
-                    Source: String,               // SAB
-                    TermType: String,             // TTY
-                    SourceEntryID: String,        // CODE
-                    EntryString: String,          // STR
-                    SourceRestriction: String,    // SRL
-                    SuppressibleFlag: String,     // SUPPRESS
-                    ContentViewFlag: String       // CVF
-                  )
-
 object DbConcepts {
   /** Wrap an RRF file using a database to cache results. */
   def fromDatabase(db: ConnectionFactory, rrfFile: RRFFile) = new DbConcepts(db, rrfFile.file, rrfFile.filename)

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -5,16 +5,20 @@ import java.sql.{Connection, PreparedStatement}
 
 import com.typesafe.scalalogging.{LazyLogging, Logger}
 import org.apache.commons.dbcp2.ConnectionFactory
+import org.renci.umls.rrf
 
 import scala.util.Try
 import org.renci.umls.rrf._
 
+import scala.collection.mutable
 import scala.io.Source
 
 /** A wrapper for RRFConcepts that uses  */
 class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RRFConcepts(file, filename) with LazyLogging {
+  /** The name of the table used to store this information. We include the SHA-256 hash so we reload it if it changes. */
   val tableName: String = "MRCONSO_" + sha256
 
+  /* Check to see if the MRCONSO_ table seems up to date. If not, load it into memory from the file. */
   val conn1 = db.createConnection()
   val checkCount = conn1.createStatement()
   val results = Try { checkCount.executeQuery(s"SELECT COUNT(*) AS cnt FROM $tableName") }
@@ -73,7 +77,94 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RR
       }
     }
     insertStmt.executeBatch()
+
+    // Add indexes.
+    regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_SAB ON $tableName (SAB);")
+
     conn.close()
+  }
+
+  // Okay, we're ready to go!
+  def getSources(): Seq[(String, Int)] = {
+    val conn = db.createConnection()
+    val query = conn.createStatement()
+    val rs = query.executeQuery(s"SELECT SAB, COUNT(*) AS count FROM $tableName GROUP BY SAB ORDER BY count DESC;")
+
+    var results = Seq[(String, Int)]()
+    while(rs.next()) {
+      results = results :+ (
+        rs.getString(1),
+        rs.getInt(2)
+      )
+    }
+
+    conn.close()
+    results
+  }
+
+  case class Map(
+    fromSource: String,
+    fromCode: String,
+    toSource: String,
+    toCode: String,
+    conceptIds: Set[String],
+    atomIds: Set[String],
+    labels: Set[String]
+  )
+  def getMap(fromSource: String, toSource: String): Seq[Map] = {
+    // Step 1. Actually retrieve the mapping information.
+    val conn = db.createConnection()
+    val query = conn.prepareStatement(s"SELECT CUI, AUI, SAB, SCUI, STR FROM $tableName WHERE SAB=? OR SAB=?;")
+    query.setString(1, fromSource)
+    query.setString(2, toSource)
+
+    val rs = query.executeQuery()
+
+    // We use the CUIs to map everything from the fromSource to the toSource.
+    case class HalfMap(cui: String, aui: String, source: String, code:String, label:String)
+
+    logger.info(s"Loading halfmaps.")
+    var halfMap = Seq[HalfMap]()
+    var count = 0
+    while(rs.next()) {
+      halfMap = HalfMap(
+        rs.getString(1),
+        rs.getString(2),
+        rs.getString(3),
+        rs.getString(4),
+        rs.getString(5)
+      ) +: halfMap
+      count += 1
+      if (count % 100000 == 0) {
+        logger.info(s"Loaded $count halfmaps.")
+      }
+    }
+    conn.close()
+    logger.info(s"${halfMap.size} halfmaps loaded.")
+
+    halfMap.groupBy(_.cui).values.flatMap({ entries =>
+      // Everything in entries is the "same" concept according to MRCONSO.
+      // So we partition this based on
+      val cuis = entries.map(_.cui).toSet
+      val auis = entries.map(_.aui).toSet
+      val labels = entries.map(_.label).toSet
+      val fromCodes = entries.filter(_.source == fromSource).map(_.code).toSet[String]
+      val toCodes = entries.filter(_.source == toSource).map(_.code).toSet[String]
+
+      fromCodes.flatMap(fromCode => {
+        toCodes.map(toCode => {
+          Map(
+            fromSource,
+            fromCode,
+            toSource,
+            toCode,
+            cuis,
+            auis,
+            labels
+          )
+        })
+      })
+    }).toSeq
   }
 }
 

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 import scala.collection.mutable
 import scala.io.Source
 
-/** A wrapper for RRFConcepts that uses  */
+/** A wrapper for RRFConcepts that uses SQLite */
 class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RRFConcepts(file, filename) with LazyLogging {
   implicit val halfMapCache: Cache[Seq[HalfMap]] = CaffeineCache[Seq[HalfMap]]
 

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -87,6 +87,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String) extends RR
 
     // Add indexes.
     regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_SAB ON $tableName (SAB);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_CODE ON $tableName (CODE);")
 
     conn.close()
   }

--- a/src/main/scala/org/renci/umls/db/DbHierarchy.scala
+++ b/src/main/scala/org/renci/umls/db/DbHierarchy.scala
@@ -1,0 +1,118 @@
+package org.renci.umls.db
+
+import java.io.File
+import java.sql.{Connection, PreparedStatement}
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.apache.commons.dbcp2.ConnectionFactory
+import org.renci.umls.rrf
+
+import scala.util.Try
+import org.renci.umls.rrf._
+
+import scala.collection.mutable
+import scala.io.Source
+
+/** Represents a single hierarchy entry. */
+case class HierarchyEntry(
+                           ConceptId: String,                  // CUI
+                           AtomId: String,                     // AUI
+                           ContextNumber: String,              // CXN
+                           ParentAtomId: String,               // PAUI
+                           Source: String,                     // SAB
+                           Relation: String,                   // RELA
+                           PathToRoot: String,                 // PTR
+                           HierarchyCode: String,              // HCD
+                           ContentViewFlag: String             // CVF
+                         )
+
+/** A wrapper for RRFHierarchy that uses SQLite */
+class DbHierarchy(db: ConnectionFactory, file: File, filename: String) extends RRFHierarchy(file, filename) with LazyLogging {
+  /** The name of the table used to store this information. We include the SHA-256 hash so we reload it if it changes. */
+  val tableName: String = "MRHIER_" + sha256
+
+  /* Check to see if the MRHIER_ table seems up to date. If not, load it into memory from the file. */
+  val conn1 = db.createConnection()
+  val checkCount = conn1.createStatement()
+  val results = Try { checkCount.executeQuery(s"SELECT COUNT(*) AS cnt FROM $tableName") }
+  val rowsFromDb = if (results.isSuccess) results.get.getInt(1) else -1
+  conn1.close()
+
+  if (rowsFromDb > 0 && rowsFromDb == rowCount) {
+    logger.info(s"Hierarchy table $tableName has $rowsFromDb rows.")
+  } else {
+    logger.info(s"Hierarchy table $tableName is not present or is out of sync. Regenerating.")
+
+    val conn = db.createConnection()
+    val regenerate = conn.createStatement()
+    regenerate.execute(s"DROP TABLE IF EXISTS $tableName")
+    regenerate.execute(s"""CREATE TABLE $tableName (
+      |CUI TEXT,
+      |AUI TEXT,
+      |CXN TEXT,
+      |PAUI TEXT,
+      |SAB TEXT,
+      |RELA TEXT,
+      |PTR TEXT,
+      |HCD TEXT,
+      |CVF TEXT
+      )""".stripMargin)
+
+    val insertStmt = conn.prepareStatement(
+      s"INSERT INTO $tableName (CUI, AUI, CXN, PAUI, SAB, RELA, PTR, HCD, CVF) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+
+    var count = 0
+    Source.fromFile(file).getLines.map(_.split("\\|", -1).toIndexedSeq) foreach { row =>
+      insertStmt.clearParameters()
+
+      (1 until 10) foreach ({ index =>
+        insertStmt.setString(index, row(index - 1))
+      })
+      insertStmt.addBatch()
+
+      count += 1
+      if (count % 100000 == 0) {
+        val percentage = count.toFloat/rowCount*100
+        logger.info(f"Batched $count rows out of $rowCount ($percentage%.2f%%), executing.")
+        insertStmt.executeBatch()
+        insertStmt.clearBatch()
+      }
+    }
+    insertStmt.executeBatch()
+
+    // Add indexes.
+    regenerate.execute(s"CREATE INDEX INDEX_MRHIER_CUI ON $tableName (CUI);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRHIER_AUI ON $tableName (AUI);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRHIER_SAB ON $tableName (SAB);")
+
+    conn.close()
+  }
+
+  override def getParents(atomIds: Seq[String]): Set[String] = {
+    if (atomIds.isEmpty) return Set()
+
+    val conn = db.createConnection()
+    val questions = atomIds.map(_ => "?").mkString(", ")
+    val query = conn.prepareStatement(s"SELECT PAUI FROM $tableName WHERE AUI IN ($questions)")
+    val indexedSeq = atomIds.toIndexedSeq
+    (1 to atomIds.size).foreach(index => {
+      query.setString(index, indexedSeq(index - 1))
+    })
+
+    var results = Seq[String]()
+    val rs = query.executeQuery()
+    while(rs.next()) {
+      results = rs.getString(1) +: results
+    }
+    conn.close()
+
+    results.toSet
+  }
+}
+
+object DbHierarchy {
+  /** Wrap an RRF file using a database to cache results. */
+  def fromDatabase(db: ConnectionFactory, rrfFile: RRFFile) = new DbHierarchy(db, rrfFile.file, rrfFile.filename)
+}

--- a/src/main/scala/org/renci/umls/db/DbHierarchy.scala
+++ b/src/main/scala/org/renci/umls/db/DbHierarchy.scala
@@ -95,7 +95,7 @@ class DbHierarchy(db: ConnectionFactory, file: File, filename: String) extends R
 
     val conn = db.createConnection()
     val questions = atomIds.map(_ => "?").mkString(", ")
-    val query = conn.prepareStatement(s"SELECT PAUI FROM $tableName WHERE AUI IN ($questions)")
+    val query = conn.prepareStatement(s"SELECT DISTINCT PAUI FROM $tableName WHERE AUI IN ($questions)")
     val indexedSeq = atomIds.toIndexedSeq
     (1 to atomIds.size).foreach(index => {
       query.setString(index, indexedSeq(index - 1))

--- a/src/main/scala/org/renci/umls/rrf/RRFCols.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFCols.scala
@@ -1,0 +1,41 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+/**
+  * The RRFCols file contains metadata on all of the columns across all files in the RRFDir.
+  */
+class RRFCols(file: File, filename: String = "MRCOLS.RRF") extends RRFFile(file, filename) {
+  /** Represents a single column entry. */
+  case class Column(
+    Name: String,
+    Description: String,
+    DocumentSectionNumber: String,
+    MinimumLength: Option[Int],
+    AverageLength: Option[Float],
+    MaximumLength: Option[Int],
+    Filename: String,
+    SQL92DataType: String
+  )
+
+  /** Return a list of all columns in an RRFCols file. */
+  def asColumns: Seq[Column] = {
+    // We'll just hard-code this for now.
+    // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
+    // right now I just don't have the time.
+    cols.map(arr => Column(
+      arr(0),
+      arr(1),
+      arr(2),
+      arr(3).trim.toIntOption,
+      arr(4).trim.toFloatOption,
+      arr(5).trim.toIntOption,
+      arr(6),
+      arr(7)
+    ))
+  }
+}
+
+object RRFCols {
+  def fromRRF(rrfFile: RRFFile) = new RRFCols(rrfFile.file, rrfFile.filename)
+}

--- a/src/main/scala/org/renci/umls/rrf/RRFCols.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFCols.scala
@@ -2,28 +2,28 @@ package org.renci.umls.rrf
 
 import java.io.File
 
+/** Represents a single column entry. */
+case class Column(
+  Name: String,
+  Description: String,
+  DocumentSectionNumber: String,
+  MinimumLength: Option[Int],
+  AverageLength: Option[Float],
+  MaximumLength: Option[Int],
+  Filename: String,
+  SQL92DataType: String
+)
+
 /**
   * The RRFCols file contains metadata on all of the columns across all files in the RRFDir.
   */
 class RRFCols(file: File, filename: String = "MRCOLS.RRF") extends RRFFile(file, filename) {
-  /** Represents a single column entry. */
-  case class Column(
-    Name: String,
-    Description: String,
-    DocumentSectionNumber: String,
-    MinimumLength: Option[Int],
-    AverageLength: Option[Float],
-    MaximumLength: Option[Int],
-    Filename: String,
-    SQL92DataType: String
-  )
-
-  /** Return a list of all columns in an RRFCols file. */
-  def asColumns: Seq[Column] = {
+  /** A list of all columns in an RRFCols file. */
+  val columns: Seq[Column] = {
     // We'll just hard-code this for now.
     // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
     // right now I just don't have the time.
-    cols.map(arr => Column(
+    rows.map(arr => Column(
       arr(0),
       arr(1),
       arr(2),
@@ -34,8 +34,20 @@ class RRFCols(file: File, filename: String = "MRCOLS.RRF") extends RRFFile(file,
       arr(7)
     ))
   }
+
+  /** Retrieve a column by name. */
+  def getColumn(name: String, filename: String): Seq[Column] = columns.filter(_.Filename == filename).filter(_.Name == name)
+  def getOnlyColumn(name: String, filename: String): Column = {
+    val results = getColumn(name, filename)
+    if (results.size < 1)
+      throw new RuntimeException(s"No column named $name found for filename $filename in ${this.filename}")
+    else if (results.size > 1)
+      throw new RuntimeException(s"Too many columns named $name found for filename $filename in ${this.filename}: $results")
+    else results.head
+  }
 }
 
 object RRFCols {
+  /** Wrap an RRF file as an RRFCols. */
   def fromRRF(rrfFile: RRFFile) = new RRFCols(rrfFile.file, rrfFile.filename)
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFConcepts.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFConcepts.scala
@@ -29,7 +29,7 @@ case class Concept(
   */
 class RRFConcepts(file: File, filename: String = "MRCONSO.RRF") extends RRFFile(file, filename) {
   /** A list of all columns in an RRFConcepts file. */
-  val concepts: Seq[Concept] = {
+  def concepts(): Seq[Concept] = {
     // We'll just hard-code this for now.
     // Eventually, it'd be nice to have this automatically settable from MRFILES.RRF itself, but
     // right now I just don't have the time.

--- a/src/main/scala/org/renci/umls/rrf/RRFConcepts.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFConcepts.scala
@@ -1,0 +1,65 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+/** Represents a single column entry. */
+case class Concept(
+  ConceptID: String,            // CUI
+  Lang: String,                 // LAT
+  TermStatus: String,           // TS
+  TermID: String,               // LUI
+  StringType: String,           // STT
+  StringID: String,             // SUI
+  IsPreferred: Boolean,         // ISPREF
+  AtomID: String,               // AUI
+  SourceAtomID: String,         // SAUI
+  SourceConceptID: String,      // SCUI
+  SourceDescriptorID: String,   // SDUI
+  Source: String,               // SAB
+  TermType: String,             // TTY
+  SourceEntryID: String,        // CODE
+  EntryString: String,          // STR
+  SourceRestriction: String,    // SRL
+  SuppressibleFlag: String,     // SUPPRESS
+  ContentViewFlag: String       // CVF
+)
+
+/**
+  * The RRFConcepts file allows you to read concept data from MRCONSO.RRF.
+  */
+class RRFConcepts(file: File, filename: String = "MRCONSO.RRF") extends RRFFile(file, filename) {
+  /** A list of all columns in an RRFConcepts file. */
+  val concepts: Seq[Concept] = {
+    // We'll just hard-code this for now.
+    // Eventually, it'd be nice to have this automatically settable from MRFILES.RRF itself, but
+    // right now I just don't have the time.
+    rows.map(arr => Concept(
+      arr(0),
+      arr(1),
+      arr(2),
+      arr(3),
+      arr(4),
+      arr(5),
+      arr(6).trim match {
+        case "Y" => true
+        case _ => false
+      },
+      arr(7),
+      arr(8),
+      arr(9),
+      arr(10),
+      arr(12),
+      arr(13),
+      arr(14),
+      arr(15),
+      arr(16),
+      arr(17),
+      arr(18)
+    ))
+  }
+}
+
+object RRFConcepts {
+  /** Wrap an RRF file as an RRFCols. */
+  def fromRRF(rrfFile: RRFFile) = new RRFConcepts(rrfFile.file, rrfFile.filename)
+}

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -4,6 +4,12 @@ import java.io.File
 
 import scala.io.Source
 
+/**
+  * Wraps an entire directory of RRF files. This generally contains a release.dat file with release information and the
+  * MRCOLS.RRF with information on all the columns across all the files.
+  *
+  * @param dir The META directory to wrap.
+  */
 class RRFDir(dir: File) {
   def getFile(filename: String): File = {
     val file = new File(dir, filename)
@@ -12,6 +18,11 @@ class RRFDir(dir: File) {
 
     file
   }
+  def getRRFFile(filename: String): RRFFile = new RRFFile(getFile(filename), filename)
 
+  /** Get the release information for this release (from release.dat) */
   val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
+
+  /** Loads the MRCOLS.RRF files and makes them available. */
+  val cols: RRFCols = RRFCols.fromRRF(getRRFFile("MRCOLS.RRF"))
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -1,7 +1,6 @@
 package org.renci.umls.rrf
 
 import java.io.File
-import java.sql.{Connection, DriverManager}
 
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory
 import org.renci.umls.db.{DbConcepts, DbHierarchy}

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -40,6 +40,9 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   /** Loads MRFILES.RRF files and makes them available. */
   val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
 
+  /** Loads MRHIER.RRF files and makes them available. */
+  val hierarchy: RRFHierarchy = RRFHierarchy.fromRRF(getRRFFile("MRHIER.RRF"))
+
   /** Loads MRCONSO.RRF files and makes them available. */
   val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -27,20 +27,20 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   def getRRFFile(filename: String): RRFFile = new RRFFile(getFile(filename), filename)
 
   /** Set up an SQLite database for us to use. */
-  val sqliteDb:DriverManagerConnectionFactory = new DriverManagerConnectionFactory("jdbc:sqlite:" + sqliteDbFile.getPath)
+  lazy val sqliteDb:DriverManagerConnectionFactory = new DriverManagerConnectionFactory("jdbc:sqlite:" + sqliteDbFile.getPath)
 
   /** Get the release information for this release (from release.dat) */
-  val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
+  lazy val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
 
   /** Loads MRCOLS.RRF files and makes them available. */
-  val cols: RRFCols = RRFCols.fromRRF(getRRFFile("MRCOLS.RRF"))
+  lazy val cols: RRFCols = RRFCols.fromRRF(getRRFFile("MRCOLS.RRF"))
 
   /** Loads MRFILES.RRF files and makes them available. */
-  val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
+  lazy val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
 
   /** Loads MRHIER.RRF files and makes them available. */
-  val hierarchy: DbHierarchy = DbHierarchy.fromDatabase(sqliteDb, getRRFFile("MRHIER.RRF"))
+  lazy val hierarchy: DbHierarchy = DbHierarchy.fromDatabase(sqliteDb, getRRFFile("MRHIER.RRF"))
 
   /** Loads MRCONSO.RRF files and makes them available. */
-  val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
+  lazy val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -1,13 +1,13 @@
 package org.renci.umls.rrf
 
 import java.io.File
+import java.sql.{Connection, DriverManager}
+
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory
 
 import org.renci.umls.db.DbConcepts
-import slick.jdbc
-import slick.jdbc.SQLiteProfile
 
 import scala.io.Source
-import slick.jdbc.SQLiteProfile.api._
 
 /**
   * Wraps an entire directory of RRF files. This generally contains a release.dat file with release information and the
@@ -29,7 +29,7 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   def getRRFFile(filename: String): RRFFile = new RRFFile(getFile(filename), filename)
 
   /** Set up an SQLite database for us to use. */
-  val sqliteDB: jdbc.SQLiteProfile.backend.DatabaseDef = Database.forURL("jdbc:sqlite:" + sqliteDbFile.getPath)
+  val sqliteDb:DriverManagerConnectionFactory = new DriverManagerConnectionFactory("jdbc:sqlite:" + sqliteDbFile.getPath)
 
   /** Get the release information for this release (from release.dat) */
   val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
@@ -41,5 +41,5 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
 
   /** Loads MRCONSO.RRF files and makes them available. */
-  val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDB, getRRFFile("MRCONSO.RRF"))
+  val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -1,0 +1,17 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+import scala.io.Source
+
+class RRFDir(dir: File) {
+  def getFile(filename: String): File = {
+    val file = new File(dir, filename)
+
+    if (!file.exists()) throw new RuntimeException(s"Directory ${dir.getCanonicalPath} does not contain expected file $filename.")
+
+    file
+  }
+
+  val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
+}

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -4,8 +4,7 @@ import java.io.File
 import java.sql.{Connection, DriverManager}
 
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory
-
-import org.renci.umls.db.DbConcepts
+import org.renci.umls.db.{DbConcepts, DbHierarchy}
 
 import scala.io.Source
 
@@ -41,7 +40,7 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
 
   /** Loads MRHIER.RRF files and makes them available. */
-  val hierarchy: RRFHierarchy = RRFHierarchy.fromRRF(getRRFFile("MRHIER.RRF"))
+  val hierarchy: DbHierarchy = DbHierarchy.fromDatabase(sqliteDb, getRRFFile("MRHIER.RRF"))
 
   /** Loads MRCONSO.RRF files and makes them available. */
   val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -23,6 +23,12 @@ class RRFDir(dir: File) {
   /** Get the release information for this release (from release.dat) */
   val releaseInfo: String = Source.fromFile(getFile("release.dat")).mkString
 
-  /** Loads the MRCOLS.RRF files and makes them available. */
+  /** Loads MRCOLS.RRF files and makes them available. */
   val cols: RRFCols = RRFCols.fromRRF(getRRFFile("MRCOLS.RRF"))
+
+  /** Loads MRFILES.RRF files and makes them available. */
+  val files: RRFFiles = RRFFiles.fromRRF(getRRFFile("MRFILES.RRF"), cols)
+
+  /** Loads MRCONSO.RRF files and makes them available. */
+  val concepts: RRFConcepts = RRFConcepts.fromRRF(getRRFFile("MRCONSO.RRF"))
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFFile.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFFile.scala
@@ -1,0 +1,12 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+import scala.io.Source
+
+/**
+  * Wraps a single RRF file.
+  */
+class RRFFile(val file: File, val filename: String) {
+  val cols: Seq[Array[String]] = Source.fromFile(file).getLines.map(_.split("\\|")).toSeq
+}

--- a/src/main/scala/org/renci/umls/rrf/RRFFile.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFFile.scala
@@ -8,5 +8,6 @@ import scala.io.Source
   * Wraps a single RRF file.
   */
 class RRFFile(val file: File, val filename: String) {
-  val cols: Seq[Array[String]] = Source.fromFile(file).getLines.map(_.split("\\|")).toSeq
+  /** A list of all rows in this file. */
+  val rows: Seq[IndexedSeq[String]] = Source.fromFile(file).getLines.map(_.split("\\|").toIndexedSeq).toSeq
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFFile.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFFile.scala
@@ -4,10 +4,18 @@ import java.io.File
 
 import scala.io.Source
 
+import org.apache.commons.codec.digest.DigestUtils
+
 /**
   * Wraps a single RRF file.
   */
 class RRFFile(val file: File, val filename: String) {
   /** A list of all rows in this file. */
-  def rows: Seq[IndexedSeq[String]] = Source.fromFile(file).getLines.map(_.split("\\|").toIndexedSeq).toSeq
+  lazy val rows: Seq[IndexedSeq[String]] = Source.fromFile(file).getLines.map(_.split("\\|").toIndexedSeq).toSeq
+
+  /** Count the number of rows in this file. */
+  lazy val rowCount: Long = Source.fromFile(file).getLines.size
+
+  /** Calculate an SHA1 hash for this file. */
+  lazy val sha256: String = new DigestUtils(DigestUtils.getSha256Digest).digestAsHex(file)
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFFile.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFFile.scala
@@ -9,5 +9,5 @@ import scala.io.Source
   */
 class RRFFile(val file: File, val filename: String) {
   /** A list of all rows in this file. */
-  val rows: Seq[IndexedSeq[String]] = Source.fromFile(file).getLines.map(_.split("\\|").toIndexedSeq).toSeq
+  def rows: Seq[IndexedSeq[String]] = Source.fromFile(file).getLines.map(_.split("\\|").toIndexedSeq).toSeq
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFFiles.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFFiles.scala
@@ -1,0 +1,52 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+/** Represents a single file entry. */
+case class FileEntry(
+  Name: String,
+  Description: String,
+  ColumnsAsString: String,
+  Columns: Array[Column],
+  NumberOfColumns: Int,
+  NumberOfRows: Option[Long],
+  SizeInBytes: Option[Long]
+)
+
+/**
+  * The RRFFiles file contains metadata on all of the files in the RRFDir. This is essential, since this contains a
+  * list of all the columns in the file.
+  */
+class RRFFiles(file: File, cols: RRFCols, filename: String = "MRFILES.RRF") extends RRFFile(file, filename) {
+  /** Return a list of all files in an RRFFiles file. */
+  def files: Seq[FileEntry] = {
+    // We'll just hard-code this for now.
+    // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
+    // right now I just don't have the time.
+    rows.map(arr => {
+      val filename = arr(0)
+      val columns = arr(2).split("\\s*,\\s*").map(cols.getOnlyColumn(_, filename))
+      val colSize = arr(3).trim.toInt
+
+      assert(
+        columns.size == colSize,
+        s"Number of columns in the string ('${arr(2)}') should equal the number in the column (${arr(4)})"
+      )
+
+      FileEntry(
+        filename,
+        arr(1),
+        arr(2),
+        columns,
+        colSize,
+        arr(4).trim.toLongOption,
+        arr(5).trim.toLongOption
+      )
+    })
+  }
+}
+
+object RRFFiles {
+  /** Wrap an RRF file as an RRFFiles class. */
+  def fromRRF(rrfFile: RRFFile, rrfCols: RRFCols) = new RRFFiles(rrfFile.file, rrfCols, rrfFile.filename)
+}

--- a/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
@@ -20,7 +20,7 @@ case class HierarchyEntry(
   */
 class RRFHierarchy(file: File, filename: String = "MRHIER.RRF") extends RRFFile(file, filename) {
   /** A list of all columns in an RRFCols file. */
-  lazy val columns: Seq[HierarchyEntry] = {
+  lazy val hierarchies: Seq[HierarchyEntry] = {
     // We'll just hard-code this for now.
     // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
     // right now I just don't have the time.
@@ -36,12 +36,13 @@ class RRFHierarchy(file: File, filename: String = "MRHIER.RRF") extends RRFFile(
       arr(8)
     ))
   }
+  lazy val hierarchiesByAtomId = hierarchies.groupBy(_.AtomId)
 
-  def getParents(atomId: String): Set[String] = columns.filter(_.AtomId == atomId).map(_.ParentAtomId).toSet
-  def getOnlyParent(atomId: String): String = {
-    val set = getParents(atomId)
-    if (set.size < 1) throw new RuntimeException(s"No parents found for atom ID: $atomId")
-    if (set.size > 1) throw new RuntimeException(s"Too many parents found for atom ID: $atomId: $set")
+  def getParents(atomIds: Seq[String]): Set[String] = atomIds.flatMap(hierarchiesByAtomId.getOrElse(_, Seq())).map(_.ParentAtomId).toSet
+  def getOnlyParent(atomIds: Seq[String]): String = {
+    val set = getParents(atomIds)
+    if (set.size < 1) throw new RuntimeException(s"No parents found for atom IDs: $atomIds")
+    if (set.size > 1) throw new RuntimeException(s"Too many parents found for atom IDs: $atomIds: $set")
     set.head
   }
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
@@ -1,0 +1,52 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+/** Represents a single hierarchy entry. */
+case class HierarchyEntry(
+  ConceptId: String,                  // CUI
+  AtomId: String,                     // AUI
+  ContextNumber: String,              // CXN
+  ParentAtomId: String,               // PAUI
+  Source: String,                     // SAB
+  Relation: String,                   // RELA
+  PathToRoot: String,                 // PTR
+  HierarchyCode: String,              // HCD
+  ContentViewFlag: String             // CVF
+)
+
+/**
+  * The RRFHierarchy file contains hierarchy information on atoms in the system.
+  */
+class RRFHierarchy(file: File, filename: String = "MRHIER.RRF") extends RRFFile(file, filename) {
+  /** A list of all columns in an RRFCols file. */
+  lazy val columns: Seq[HierarchyEntry] = {
+    // We'll just hard-code this for now.
+    // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
+    // right now I just don't have the time.
+    rows.map(arr => HierarchyEntry(
+      arr(0),
+      arr(1),
+      arr(2),
+      arr(3),
+      arr(4),
+      arr(5),
+      arr(6),
+      arr(7),
+      arr(8)
+    ))
+  }
+
+  def getParents(atomId: String): Set[String] = columns.filter(_.AtomId == atomId).map(_.ParentAtomId).toSet
+  def getOnlyParent(atomId: String): String = {
+    val set = getParents(atomId)
+    if (set.size < 1) throw new RuntimeException(s"No parents found for atom ID: $atomId")
+    if (set.size > 1) throw new RuntimeException(s"Too many parents found for atom ID: $atomId: $set")
+    set.head
+  }
+}
+
+object RRFHierarchy {
+  /** Wrap an RRF file as an RRFHierarchy. */
+  def fromRRF(rrfFile: RRFFile) = new RRFHierarchy(rrfFile.file, rrfFile.filename)
+}


### PR DESCRIPTION
A simple term mapper built around the NCI Metathesaurus. It can produce the entire known mapping, or only map a list of input terms. Most RRF files are loaded directly into memory, but since two critical files we need (MRCONSO and MRHIER) are particularly large, we load those into a local SQLite3 database and query them from there. It also includes support for matching via the parent term, i.e. when term X in source A has no mapping in source B, but X's parent term does.