### PR TITLE
Use relations from MRREL

### DIFF
--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -135,7 +135,9 @@ object CodeMapper extends App {
               val rels = rrfDir.relationships.getRelationshipsByCUIs(termCuis.toSet)
               rels
                 .filter(r => r.rel.equals("PAR")) // Only look for PARent relations.
-                .filter(r => !r.cui1.equals(r.cui2) && !termCuis.contains(r.cui2)) // Make sure we're not accidentally finding relations to ourselves.
+                .filter(
+                  r => !r.cui1.equals(r.cui2) && !termCuis.contains(r.cui2)
+                ) // Make sure we're not accidentally finding relations to ourselves.
                 .map(_.cui2)
                 .toSet
             } else {
@@ -177,8 +179,10 @@ object CodeMapper extends App {
             .groupBy(r => if (r.rela.isEmpty) r.rel else s"${r.rel}:${r.rela}")
             .transform((relName, rs) => {
               // If there are fewer than four examples, list all three.
-              val examples = if (rs.size < 4) rs.map(r => s"${r.cui2} + [${r.label2}]").mkString(", ")
-              else s"${rs.take(3).map(r => s"${r.cui2} [${r.label2}]").mkString(", ")}...${rs.size - 3} other"
+              val examples =
+                if (rs.size < 4) rs.map(r => s"${r.cui2} + [${r.label2}]").mkString(", ")
+                else
+                  s"${rs.take(3).map(r => s"${r.cui2} [${r.label2}]").mkString(", ")}...${rs.size - 3} other"
 
               (rs.size, s"${relName} (${examples})")
             })
@@ -189,18 +193,28 @@ object CodeMapper extends App {
             .mkString(", ")
         }
 
-        lazy val relsFromTermStr = if (maps.nonEmpty) "" else {
-          val relationshipsFromTerm = rrfDir.relationships.getRelationshipsByCUIs(termCUIs)
-          scribe.info(s"Found relationships for ${termCUIs.mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(termCUIs, relationshipsFromTerm)}")
-          summarizeRelationships(termCUIs, relationshipsFromTerm)
-        }
+        lazy val relsFromTermStr =
+          if (maps.nonEmpty) ""
+          else {
+            val relationshipsFromTerm = rrfDir.relationships.getRelationshipsByCUIs(termCUIs)
+            scribe.info(
+              s"Found relationships for ${termCUIs
+                .mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(termCUIs, relationshipsFromTerm)}"
+            )
+            summarizeRelationships(termCUIs, relationshipsFromTerm)
+          }
 
-        lazy val relsFromParentStr = if (maps.nonEmpty || parentHalfMaps.isEmpty) "" else {
-          val parentCUIs = parentHalfMaps.map(_.cui).toSet
-          val relationshipsFromParent = rrfDir.relationships.getRelationshipsByCUIs(parentCUIs)
-          scribe.info(s"Found relationships for parent of ${termCUIs.mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(parentCUIs, relationshipsFromParent)}")
-          summarizeRelationships(parentCUIs, relationshipsFromParent)
-        }
+        lazy val relsFromParentStr =
+          if (maps.nonEmpty || parentHalfMaps.isEmpty) ""
+          else {
+            val parentCUIs = parentHalfMaps.map(_.cui).toSet
+            val relationshipsFromParent = rrfDir.relationships.getRelationshipsByCUIs(parentCUIs)
+            scribe.info(
+              s"Found relationships for parent of ${termCUIs
+                .mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(parentCUIs, relationshipsFromParent)}"
+            )
+            summarizeRelationships(parentCUIs, relationshipsFromParent)
+          }
 
         stream.println(
           s"${conf.fromSource()}\t$id\t${termCUIs.mkString("|")}\t${halfMaps
@@ -209,9 +223,9 @@ object CodeMapper extends App {
             .mkString("|")}\t${maps.size}\t${parentHalfMaps.size}"
             + s"\t${maps.map(m => m.toSource + ":" + m.toCode).mkString("|")}"
             + s"\t${maps.map(_.labels.mkString(";")).mkString("|")}"
-            //+ s"\t${relsFromTermStr}"
+          //+ s"\t${relsFromTermStr}"
             + s"$parentStr"
-            //+ s"\t${relsFromParentStr}"
+          //+ s"\t${relsFromParentStr}"
         )
 
         count += 1

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -84,6 +84,7 @@ object CodeMapper extends App {
     // Both sourceFrom and sourceTo are set!
     if (conf.idFile.isEmpty) {
       val maps = concepts.getMap(conf.fromSource(), Seq.empty, conf.toSource(), Seq.empty)
+
       stream.println("fromSource\tfromCode\ttoSource\ttoCode\tnciMTConceptIds\tlabels")
       maps.foreach(map => {
         stream.println(
@@ -92,6 +93,9 @@ object CodeMapper extends App {
             s"${map.conceptIds.mkString(", ")}\t" +
             s"${map.labels.mkString("|")}"
         )
+
+        val relations = rrfDir.relationships.getRelationshipsByCUIs(map.conceptIds)
+        scribe.info(s"Relations identified: ${relations.map(_ + "\n - ")}")
       })
     } else {
       val ids = Source.fromFile(conf.idFile()).getLines.map(_.trim).toSeq

--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -2,6 +2,7 @@ package org.renci.umls
 
 import java.io.{File, FileOutputStream, PrintStream}
 
+import org.renci.umls.db.Relation
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
 import org.renci.umls.rrf.RRFDir
@@ -47,6 +48,12 @@ object CodeMapper extends App {
       opt[File](descr = "A file containing identifiers (in a single, newline-delimited column)")
 
     val outputFile: ScallopOption[File] = opt[File](descr = "Where to write the output file")
+
+    val parentBy: ScallopOption[String] = opt[String](
+      descr = "How to calculate the parent of the present term",
+      default = Some("MRREL"),
+      validate = (v: String) => Set("MRREL", "MRHIER").contains(v)
+    )
 
     verify()
   }
@@ -106,7 +113,7 @@ object CodeMapper extends App {
       val allTermCuis = concepts.getCUIsForCodes(conf.fromSource(), ids)
 
       stream.println(
-        "fromSource\tid\tcuis\tlabels\tcountDirect\tcountViaParent\ttoIds\ttoLabels\tparentCuis\tparentSource\tparentIds\tparentLabels"
+        "fromSource\tid\tcuis\tlabels\tcountDirect\tcountViaParent\ttoIds\ttoLabels\trelationshipTypes\tparentCuis\tparentSource\tparentIds\tparentLabels\tparentRelationshipTypes"
       )
 
       var count = 0
@@ -119,9 +126,24 @@ object CodeMapper extends App {
             val termCuis = allTermCuis.getOrElse(id, Seq.empty)
             // scribe.info(s"Checking $termCuis for parent AUI information.")
 
-            val termAtomIds = concepts.getAUIsForCUIs(termCuis)
-            val parentAtomIds = rrfDir.hierarchy.getParents(termAtomIds)
-            val parentCUIs = concepts.getCUIsForAUI(parentAtomIds.toSeq)
+            val parentBy = conf.parentBy.getOrElse("")
+            val parentCUIs: Set[String] = if (parentBy.equals("MRHIER")) {
+              val termAtomIds = concepts.getAUIsForCUIs(termCuis)
+              val parentAtomIds = rrfDir.hierarchy.getParents(termAtomIds)
+              concepts.getCUIsForAUI(parentAtomIds.toSeq)
+            } else if (parentBy.equals("MRREL")) {
+              val rels = rrfDir.relationships.getRelationshipsByCUIs(termCuis.toSet)
+              rels
+                .filter(r => r.rel.equals("PAR")) // Only look for PARent relations.
+                .filter(r => !r.cui1.equals(r.cui2) && !termCuis.contains(r.cui2)) // Make sure we're not accidentally finding relations to ourselves.
+                .map(_.cui2)
+                .toSet
+            } else {
+              throw new RuntimeException(s"Unknown --parent-by provided: ${parentBy}.")
+            }
+
+            scribe.info(s"Found ${parentCUIs.size} parent CUIs for terms ${termCuis}")
+
             val halfMaps =
               if (parentCUIs.isEmpty) Seq.empty
               else concepts.getMapsByCUIs(parentCUIs.toSeq, conf.toSource())
@@ -139,15 +161,57 @@ object CodeMapper extends App {
           }
 
         val halfMaps = halfMapByCode.getOrElse(id, Seq())
+        val termCUIs = halfMaps.map(_.cui).toSet
+
+        /**
+          * Summarizes relationships in this format:
+          *   RO:isa (cui1, cui2, cui3, ... 45 others), CHD:isa (cui1, cui2, cui3, ... 43)
+          *
+          * @param rels
+          * @return
+          */
+        def summarizeRelationships(cuis: Set[String], rels: Seq[Relation]): String = {
+          rels
+            // Let's ignore self-referential relations.
+            .filter(r => r.cui1 != r.cui2 && !cuis.contains(r.cui2))
+            .groupBy(r => if (r.rela.isEmpty) r.rel else s"${r.rel}:${r.rela}")
+            .transform((relName, rs) => {
+              // If there are fewer than four examples, list all three.
+              val examples = if (rs.size < 4) rs.map(r => s"${r.cui2} + [${r.label2}]").mkString(", ")
+              else s"${rs.take(3).map(r => s"${r.cui2} [${r.label2}]").mkString(", ")}...${rs.size - 3} other"
+
+              (rs.size, s"${relName} (${examples})")
+            })
+            .values
+            .toSeq
+            .sortBy(_._1)(Ordering.Int.reverse)
+            .map(_._2)
+            .mkString(", ")
+        }
+
+        lazy val relsFromTermStr = if (maps.nonEmpty) "" else {
+          val relationshipsFromTerm = rrfDir.relationships.getRelationshipsByCUIs(termCUIs)
+          scribe.info(s"Found relationships for ${termCUIs.mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(termCUIs, relationshipsFromTerm)}")
+          summarizeRelationships(termCUIs, relationshipsFromTerm)
+        }
+
+        lazy val relsFromParentStr = if (maps.nonEmpty || parentHalfMaps.isEmpty) "" else {
+          val parentCUIs = parentHalfMaps.map(_.cui).toSet
+          val relationshipsFromParent = rrfDir.relationships.getRelationshipsByCUIs(parentCUIs)
+          scribe.info(s"Found relationships for parent of ${termCUIs.mkString("|")} [${halfMaps.map(_.label).headOption.getOrElse("")}]: ${summarizeRelationships(parentCUIs, relationshipsFromParent)}")
+          summarizeRelationships(parentCUIs, relationshipsFromParent)
+        }
 
         stream.println(
-          s"${conf.fromSource()}\t$id\t${halfMaps.map(_.cui).toSet.mkString("|")}\t${halfMaps
+          s"${conf.fromSource()}\t$id\t${termCUIs.mkString("|")}\t${halfMaps
             .map(_.label)
             .toSet
             .mkString("|")}\t${maps.size}\t${parentHalfMaps.size}"
             + s"\t${maps.map(m => m.toSource + ":" + m.toCode).mkString("|")}"
             + s"\t${maps.map(_.labels.mkString(";")).mkString("|")}"
+            //+ s"\t${relsFromTermStr}"
             + s"$parentStr"
+            //+ s"\t${relsFromParentStr}"
         )
 
         count += 1

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -83,6 +83,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     insertStmt.executeBatch()
 
     // Add indexes.
+    regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_CUI ON $tableName (CUI);")
     regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_SAB ON $tableName (SAB);")
     regenerate.execute(s"CREATE INDEX INDEX_MRCONSO_CODE ON $tableName (CODE);")
 

--- a/src/main/scala/org/renci/umls/db/DbRelationships.scala
+++ b/src/main/scala/org/renci/umls/db/DbRelationships.scala
@@ -1,0 +1,164 @@
+package org.renci.umls.db
+
+import java.io.File
+
+import org.apache.commons.dbcp2.ConnectionFactory
+
+import scala.util.Try
+import org.renci.umls.rrf._
+
+import scala.io.Source
+
+/** Represents a single hierarchy entry. */
+case class Relationship(
+  ConceptId1: String,     // CUI1
+  AtomId1: String,        // AUI1
+  SourceType1: String,    // STYPE1
+  Relationship: String,   // REL
+  ConceptId2: String,     // CUI2
+  AtomId2: String,        // AUI2
+  SourceType2: String,    // STYPE2
+  SpecificRelationship: String, // RELA
+  RelationshipId: String, // RUI
+  SourceRelationshipId: String, // SRUI
+  AbbrSourceName: String, // SAB
+  RelationshipLabelSource: String, // SL
+  RelationshipGroup: String, // RG
+  SourceAssertedDirectionality: String, // DIR
+  Suppressible: String, // SUPPRESS
+  ContentViewFlag: String // CVF
+)
+
+case class Relation(
+  cui1: String,
+  label1: String,
+  aui1: String,
+  rel: String,
+  rela: String,
+  direction: String,
+  cui2: String,
+  label2: String,
+  aui2: String
+)
+
+/** A wrapper for RRFRelationships that uses SQLite */
+class DbRelationships(db: ConnectionFactory, file: File, filename: String, dbConcepts: DbConcepts)
+    extends RRFHierarchy(file, filename) {
+  /** The name of the table used to store this information. We include the SHA-256 hash so we reload it if it changes. */
+  val tableName: String = "MRREL_" + sha256
+
+  /* Check to see if the MRREL_ table seems up to date. If not, load it into memory from the file. */
+  val conn1 = db.createConnection()
+  val checkCount = conn1.createStatement()
+  val results = Try { checkCount.executeQuery(s"SELECT COUNT(*) AS cnt FROM $tableName") }
+  val rowsFromDb = if (results.isSuccess) results.get.getInt(1) else -1
+  conn1.close()
+
+  if (rowsFromDb > 0 && rowsFromDb == rowCount) {
+    scribe.info(s"Relationships table $tableName has $rowsFromDb rows.")
+  } else {
+    scribe.info(s"Relationships table $tableName is not present or is out of sync. Regenerating.")
+
+    val conn = db.createConnection()
+    val regenerate = conn.createStatement()
+    regenerate.execute(s"DROP TABLE IF EXISTS $tableName")
+    regenerate.execute(s"""CREATE TABLE $tableName (
+      |CUI1 TEXT,
+      |AUI1 TEXT,
+      |STYPE1 TEXT,
+      |REL TEXT,
+      |CUI2 TEXT,
+      |AUI2 TEXT,
+      |STYPE2 TEXT,
+      |RELA TEXT,
+      |RUI TEXT,
+      |SRUI TEXT,
+      |SAB TEXT,
+      |SL TEXT,
+      |RG TEXT,
+      |DIR TEXT,
+      |SUPPRESS TEXT,
+      |CVF TEXT
+      )""".stripMargin)
+
+    val insertStmt = conn.prepareStatement(
+      s"INSERT INTO $tableName (CUI1, AUI1, STYPE1, REL, CUI2, AUI2, STYPE2, RELA, RUI, SRUI, SAB, SL, RG, DIR, SUPPRESS, CVF) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+
+    var count = 0
+    Source.fromFile(file).getLines.map(_.split("\\|", -1).toIndexedSeq) foreach { row =>
+      insertStmt.clearParameters()
+
+      (1 until 17) foreach ({ index =>
+        insertStmt.setString(index, row(index - 1))
+      })
+      insertStmt.addBatch()
+
+      count += 1
+      if (count % 100000 == 0) {
+        val percentage = count.toFloat / rowCount * 100
+        scribe.info(f"Batched $count rows out of $rowCount ($percentage%.2f%%), executing.")
+        insertStmt.executeBatch()
+        insertStmt.clearBatch()
+      }
+    }
+    insertStmt.executeBatch()
+
+    // Add indexes.
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_CUI1 ON $tableName (CUI1);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_CUI2 ON $tableName (CUI2);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_AUI1 ON $tableName (AUI1);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_AUI2 ON $tableName (AUI2);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_REL ON $tableName (REL);")
+    regenerate.execute(s"CREATE INDEX INDEX_MRREL_RELA ON $tableName (RELA);")
+
+    conn.close()
+  }
+
+  def getRelationshipsByCUIs(cuis: Set[String]): Seq[Relation] = {
+    if (cuis.isEmpty) return Seq.empty
+
+    val mrconso_tablename = dbConcepts.tableName
+    val conn = db.createConnection()
+    val questions = cuis.map(_ => "?").mkString(", ")
+    val query =
+      conn.prepareStatement(s"""
+      SELECT DISTINCT CUI1, mrconso1.STR AS label1, AUI1, REL, RELA, DIR, CUI2, mrconso2.STR AS label2, AUI2
+      FROM $tableName
+        LEFT JOIN ${mrconso_tablename} AS mrconso1 ON CUI1=mrconso1.CUI
+        LEFT JOIN ${mrconso_tablename} AS mrconso2 ON CUI2=mrconso2.CUI
+      WHERE CUI1 IN ($questions) OR CUI2 IN ($questions)
+      ;""")
+    val indexedSeq = cuis.toIndexedSeq
+    (1 to cuis.size).foreach(index => {
+      query.setString(index, indexedSeq(index - 1))
+      query.setString(index + cuis.size, indexedSeq(index - 1))
+    })
+
+    var results = Seq[Relation]()
+    val rs = query.executeQuery()
+    while (rs.next()) {
+      results = Relation(
+        rs.getString(1),
+        rs.getString(2),
+        rs.getString(3),
+        rs.getString(4),
+        rs.getString(5),
+        rs.getString(6),
+        rs.getString(7),
+        rs.getString(8),
+        rs.getString(9)
+      ) +: results
+    }
+    conn.close()
+
+    results
+  }
+}
+
+object DbRelationships {
+  /** Wrap an RRF file using a database to cache results. */
+  def fromDatabase(db: ConnectionFactory, rrfFile: RRFFile, dbConcepts: DbConcepts) =
+    new DbRelationships(db, rrfFile.file, rrfFile.filename, dbConcepts: DbConcepts)
+}

--- a/src/main/scala/org/renci/umls/db/DbRelationships.scala
+++ b/src/main/scala/org/renci/umls/db/DbRelationships.scala
@@ -11,13 +11,13 @@ import scala.io.Source
 
 /** Represents a single hierarchy entry. */
 case class Relationship(
-  ConceptId1: String,     // CUI1
-  AtomId1: String,        // AUI1
-  SourceType1: String,    // STYPE1
-  Relationship: String,   // REL
-  ConceptId2: String,     // CUI2
-  AtomId2: String,        // AUI2
-  SourceType2: String,    // STYPE2
+  ConceptId1: String, // CUI1
+  AtomId1: String, // AUI1
+  SourceType1: String, // STYPE1
+  Relationship: String, // REL
+  ConceptId2: String, // CUI2
+  AtomId2: String, // AUI2
+  SourceType2: String, // STYPE2
   SpecificRelationship: String, // RELA
   RelationshipId: String, // RUI
   SourceRelationshipId: String, // SRUI
@@ -44,6 +44,7 @@ case class Relation(
 /** A wrapper for RRFRelationships that uses SQLite */
 class DbRelationships(db: ConnectionFactory, file: File, filename: String, dbConcepts: DbConcepts)
     extends RRFHierarchy(file, filename) {
+
   /** The name of the table used to store this information. We include the SHA-256 hash so we reload it if it changes. */
   val tableName: String = "MRREL_" + sha256
 
@@ -199,6 +200,7 @@ class DbRelationships(db: ConnectionFactory, file: File, filename: String, dbCon
 }
 
 object DbRelationships {
+
   /** Wrap an RRF file using a database to cache results. */
   def fromDatabase(db: ConnectionFactory, rrfFile: RRFFile, dbConcepts: DbConcepts) =
     new DbRelationships(db, rrfFile.file, rrfFile.filename, dbConcepts: DbConcepts)

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -50,5 +50,6 @@ class RRFDir(dir: File, sqliteDbFile: File) {
   lazy val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
 
   /** Loads MRREL.RRF files and makes them available. */
-  lazy val relationships: DbRelationships = DbRelationships.fromDatabase(sqliteDb, getRRFFile("MRREL.RRF"), concepts)
+  lazy val relationships: DbRelationships =
+    DbRelationships.fromDatabase(sqliteDb, getRRFFile("MRREL.RRF"), concepts)
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFDir.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFDir.scala
@@ -3,7 +3,7 @@ package org.renci.umls.rrf
 import java.io.File
 
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory
-import org.renci.umls.db.{DbConcepts, DbHierarchy}
+import org.renci.umls.db.{DbConcepts, DbHierarchy, DbRelationships}
 
 import scala.io.Source
 
@@ -48,4 +48,7 @@ class RRFDir(dir: File, sqliteDbFile: File) {
 
   /** Loads MRCONSO.RRF files and makes them available. */
   lazy val concepts: DbConcepts = DbConcepts.fromDatabase(sqliteDb, getRRFFile("MRCONSO.RRF"))
+
+  /** Loads MRREL.RRF files and makes them available. */
+  lazy val relationships: DbRelationships = DbRelationships.fromDatabase(sqliteDb, getRRFFile("MRREL.RRF"), concepts)
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFRelationships.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFRelationships.scala
@@ -4,13 +4,13 @@ import java.io.File
 
 /** Represents a single hierarchy entry. */
 case class Relationship(
-  ConceptId1: String,     // CUI1
-  AtomId1: String,        // AUI1
-  SourceType1: String,    // STYPE1
-  Relationship: String,   // REL
-  ConceptId2: String,     // CUI2
-  AtomId2: String,        // AUI2
-  SourceType2: String,    // STYPE2
+  ConceptId1: String, // CUI1
+  AtomId1: String, // AUI1
+  SourceType1: String, // STYPE1
+  Relationship: String, // REL
+  ConceptId2: String, // CUI2
+  AtomId2: String, // AUI2
+  SourceType2: String, // STYPE2
   SpecificRelationship: String, // RELA
   RelationshipId: String, // RUI
   SourceRelationshipId: String, // SRUI
@@ -26,20 +26,39 @@ case class Relationship(
   * The RRFRelationships file contains relationship information on atoms in the system.
   */
 class RRFRelationships(file: File, filename: String = "MRREL.RRF") extends RRFFile(file, filename) {
+
   /** A list of all relationships in an MRREL file. */
   lazy val relationships: Seq[Relationship] = {
     // We'll just hard-code this for now.
     // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
     // right now I just don't have the time.
     rows.map(
-      arr => Relationship(arr(0), arr(1), arr(2), arr(3), arr(4), arr(5), arr(6), arr(7), arr(8), arr(9), arr(10), arr(11), arr(12), arr(13), arr(14), arr(15))
+      arr =>
+        Relationship(
+          arr(0),
+          arr(1),
+          arr(2),
+          arr(3),
+          arr(4),
+          arr(5),
+          arr(6),
+          arr(7),
+          arr(8),
+          arr(9),
+          arr(10),
+          arr(11),
+          arr(12),
+          arr(13),
+          arr(14),
+          arr(15)
+        )
     )
   }
-
 
 }
 
 object RRFRelationships {
+
   /** Wrap an RRF file as an RRFHierarchy. */
   def fromRRF(rrfFile: RRFFile) = new RRFRelationships(rrfFile.file, rrfFile.filename)
 }

--- a/src/main/scala/org/renci/umls/rrf/RRFRelationships.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFRelationships.scala
@@ -1,0 +1,45 @@
+package org.renci.umls.rrf
+
+import java.io.File
+
+/** Represents a single hierarchy entry. */
+case class Relationship(
+  ConceptId1: String,     // CUI1
+  AtomId1: String,        // AUI1
+  SourceType1: String,    // STYPE1
+  Relationship: String,   // REL
+  ConceptId2: String,     // CUI2
+  AtomId2: String,        // AUI2
+  SourceType2: String,    // STYPE2
+  SpecificRelationship: String, // RELA
+  RelationshipId: String, // RUI
+  SourceRelationshipId: String, // SRUI
+  AbbrSourceName: String, // SAB
+  RelationshipLabelSource: String, // SL
+  RelationshipGroup: String, // RG
+  SourceAssertedDirectionality: String, // DIR
+  Suppressible: String, // SUPPRESS
+  ContentViewFlag: String // CVF
+)
+
+/**
+  * The RRFRelationships file contains relationship information on atoms in the system.
+  */
+class RRFRelationships(file: File, filename: String = "MRREL.RRF") extends RRFFile(file, filename) {
+  /** A list of all relationships in an MRREL file. */
+  lazy val relationships: Seq[Relationship] = {
+    // We'll just hard-code this for now.
+    // Eventually, it'd be nice to have this automatically settable from MRCOLS.RRF itself, but
+    // right now I just don't have the time.
+    rows.map(
+      arr => Relationship(arr(0), arr(1), arr(2), arr(3), arr(4), arr(5), arr(6), arr(7), arr(8), arr(9), arr(10), arr(11), arr(12), arr(13), arr(14), arr(15))
+    )
+  }
+
+
+}
+
+object RRFRelationships {
+  /** Wrap an RRF file as an RRFHierarchy. */
+  def fromRRF(rrfFile: RRFFile) = new RRFRelationships(rrfFile.file, rrfFile.filename)
+}


### PR DESCRIPTION
This PR tries to use the mappings from MRREL to supplement the information from MRCONSO in mapping from one vocabulary to another. There any many relations in MRREL, and this PR provides methods for accessing them. However, it appears that all the hierarchy information obtained from MRREL was already present in the MRHIER table we were using earlier. Therefore, I'm going to put this PR on hiatus until we actually need to tap into the MRREL information. 

Should be merged after #5.