### PR TITLE
Memoized the getParents() method

### DIFF
--- a/src/main/scala/org/renci/umls/CodeMapper.scala
+++ b/src/main/scala/org/renci/umls/CodeMapper.scala
@@ -116,7 +116,7 @@ object CodeMapper extends App {
             // scribe.info(s"Checking $termCuis for parent AUI information.")
 
             val termAtomIds = concepts.getAUIsForCUIs(termCuis)
-            val parentAtomIds = rrfDir.hierarchy.getParents(termAtomIds)
+            val parentAtomIds = rrfDir.hierarchy.getParents(termAtomIds.toSet)
             val parentCUIs = concepts.getCUIsForAUI(parentAtomIds.toSeq)
             val halfMaps =
               if (parentCUIs.isEmpty) Seq.empty

--- a/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
+++ b/src/main/scala/org/renci/umls/rrf/RRFHierarchy.scala
@@ -31,9 +31,9 @@ class RRFHierarchy(file: File, filename: String = "MRHIER.RRF") extends RRFFile(
   }
   lazy val hierarchiesByAtomId = hierarchies.groupBy(_.AtomId)
 
-  def getParents(atomIds: Seq[String]): Set[String] =
+  def getParents(atomIds: Set[String]): Set[String] =
     atomIds.flatMap(hierarchiesByAtomId.getOrElse(_, Seq())).map(_.ParentAtomId).toSet
-  def getOnlyParent(atomIds: Seq[String]): String = {
+  def getOnlyParent(atomIds: Set[String]): String = {
     val set = getParents(atomIds)
     if (set.size < 1) throw new RuntimeException(s"No parents found for atom IDs: $atomIds")
     if (set.size > 1)


### PR DESCRIPTION
I noticed while profiling this code that the getParents() method is called quite frequently, so I added [Scalacache](https://cb372.github.io/scalacache/)-based memoization to it.

Should be merged after PR #5.