### PR TITLE
Fill from ontology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-# umls-rrf-scala
-A very basic library for parsing files in the UMLS RRF format
+# UMLS/NCImt/NCIt tools
+This is a set of tools for working with the UMLS RRF format,
+NCI Metathesaurus and NCI Thesaurus.
 
-## How to use
+## umls-rrf-scala
+A very basic library for parsing files in the UMLS RRF format.
+
 This program expects the `META` directory from the
 [NLM UMLS download](https://www.nlm.nih.gov/research/umls/index.html)
 to be in the directory where the program is executed. The `--rrf-dir`
 command line argument can also be used to point to the `META` directory
-in another directory.
+in another directory. Output is produced in the
+[SSSOM format](https://github.com/OBOFoundry/SSSOM).
 
 ```console
-$ sbt "run --from-source SNOMEDCT_US --to-source NCI -o mappings.txt"
+$ sbt "run --from-source SNOMEDCT_US --to-source NCI -o mappings.tsv"
 [info] Loading settings for project global-plugins from metals.sbt ...
 [info] Loading global plugins from /Users/gaurav/.sbt/1.0/plugins
 [info] Loading settings for project umls-rrf-scala-build from plugins.sbt ...
@@ -45,4 +49,37 @@ $ sbt "run --from-source SNOMEDCT_US --to-source NCI -o mappings.txt"
 [info] 15:32:55.204 [main] INFO  org.renci.umls.db.DbConcepts - Loaded 300000 halfmaps.
 [info] 15:32:55.473 [main] INFO  org.renci.umls.db.DbConcepts - 343103 halfmaps loaded.
 [success] Total time: 26 s, completed Apr 15, 2020, 3:32:58 PM
+```
+
+### Filler
+Filler takes in a set of mappings in the SSSOM format and attempts to fill in
+missing mappings based on its command line arguments.
+
+```console
+$ JAVA_OPTS="-Xmx16G" sbt "runMain org.renci.sssom.Filler --input-file matched-with-ols-lbo.tsv --output-file matched-with-ols-lbo-hp-chebi.tsv --fill-predicate-id 'skos:narrowMatch' --from-ontology ontologies/hp.owl --from-ontology ontologies/chebi.owl"
+[info] Loading settings for project global-plugins from metals.sbt ...
+[info] Loading global plugins from /Users/gaurav/.sbt/1.0/plugins
+[info] Loading settings for project umls-rrf-scala-build from plugins.sbt ...
+[info] Loading project definition from /Users/gaurav/Development/umls-rrf-scala/project
+[info] Loading settings for project umls-rrf-scala from build.sbt ...
+[info] Set current project to umls-rrf (in build file:/Users/gaurav/Development/umls-rrf-scala/)
+[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
+[info] running (fork) org.renci.sssom.Filler --input-file matched-with-ols-lbo.tsv --output-file matched-with-ols-lbo-hp-chebi.tsv --fill-predicate-id 'skos:narrowMatch' --from-ontology ontologies/hp.owl --from-ontology ontologies/chebi.owl
+[error] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+[error] SLF4J: Defaulting to no-operation (NOP) logger implementation
+[error] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+[info] 2020.09.16 21:14:28 [INFO] org.renci.sssom.ontologies.OntologyFiller:24:14 - Loaded ontology ontologies/hp.owl containing 953183 triples.
+[info] 2020.09.16 21:15:03 [INFO] org.renci.sssom.ontologies.OntologyFiller:24:14 - Loaded ontology ontologies/chebi.owl containing 4924892 triples.
+[info] 2020.09.16 21:15:03 [INFO] org.renci.sssom.Filler:63:14 - Active row fillers: OntologyFiller(ontologies/hp.owl), OntologyFiller(ontologies/chebi.owl)
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler.<local Filler>:95:20 - Filled subject ID SNOMEDCT_US:8836009 with ArraySeq(HashMap(predicate_label -> gallocyanin, predicate_id -> http://purl.obolibrary.org/obo/CHEBI_90106, comment -> Ontology ontologies/chebi.owl contains triple asserting http://purl.obolibrary.org/obo/CHEBI_90106 @http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym "Gallocyanine", mapping_set_version -> , subject_label -> Gallocyanine stain (substance)|Gallocyanine|Gallocyanine stain, subject_id -> SNOMEDCT_US:8836009, mapping_set_id -> , object_label -> , match_type -> , object_id -> ))
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler.<local Filler>:95:20 - Filled subject ID SNOMEDCT_US:11780008 with ArraySeq(HashMap(predicate_label -> Sirius red 4B, predicate_id -> http://purl.obolibrary.org/obo/CHEBI_88191, comment -> Ontology ontologies/chebi.owl contains triple asserting http://purl.obolibrary.org/obo/CHEBI_88191 @http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym "Chlorantine fast red 5B", mapping_set_version -> , subject_label -> Chlorantine fast red 5B|Durazol red stain|Chlorantine fast red|Durazol red stain (substance)|Durazol red, subject_id -> SNOMEDCT_US:11780008, mapping_set_id -> , object_label -> , match_type -> , object_id -> ))
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler.<local Filler>:95:20 - Filled subject ID SNOMEDCT_US:38707008 with ArraySeq(HashMap(predicate_label -> Celestin blue B, predicate_id -> http://purl.obolibrary.org/obo/CHEBI_88183, comment -> Ontology ontologies/chebi.owl contains triple asserting http://purl.obolibrary.org/obo/CHEBI_88183 @http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym "Mordant blue 14", mapping_set_version -> , subject_label -> Coelestine blue|Coelestine blue B stain|Celestine blue B stain (substance)|Celestine blue|Celestine blue B stain|Mordant blue 14, subject_id -> SNOMEDCT_US:38707008, mapping_set_id -> , object_label -> , match_type -> , object_id -> ))
+[...]
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler.<local Filler>:95:20 - Filled subject ID SNOMEDCT_US:406969006 with ArraySeq(HashMap(predicate_label -> thionine, predicate_id -> http://purl.obolibrary.org/obo/CHEBI_52295, comment -> Ontology ontologies/chebi.owl contains triple asserting http://purl.obolibrary.org/obo/CHEBI_52295 @http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym "Thionin", mapping_set_version -> , subject_label -> Thionin|Thionin stain|Thionin stain (substance), subject_id -> SNOMEDCT_US:406969006, mapping_set_id -> , object_label -> , match_type -> , object_id -> ))
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler.<local Filler>:95:20 - Filled subject ID SNOMEDCT_US:406990003 with ArraySeq(HashMap(predicate_label -> methyl blue free acid, predicate_id -> http://purl.obolibrary.org/obo/CHEBI_87477, comment -> Ontology ontologies/chebi.owl contains triple asserting http://purl.obolibrary.org/obo/CHEBI_87477 @http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym "Aniline blue", mapping_set_version -> , subject_label -> Aniline blue stain (substance)|Aniline blue stain|Aniline blue, subject_id -> SNOMEDCT_US:406990003, mapping_set_id -> , object_label -> , match_type -> , object_id -> ))
+[info] 2020.09.16 21:15:04 [INFO] org.renci.sssom.Filler:110:14 - Out of 7980 rows:
+[info]   - 5546 rows (69.50%) have existing terms.
+[info]   - 2426 rows (30.40%) could not be matched.
+[info]   - 8 rows (0.10%) could be matched.
+[success] Total time: 44 s, completed Sep 16, 2020, 9:15:05 PM
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,9 @@ libraryDependencies ++= {
     // Command line argument parsing.
     "org.rogach"                  %% "scallop"                % "3.3.2",
 
+    // Add support for CSV.
+    "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
+
     // Import Apache Jena to read JSON-LD.
     // "org.apache.jena"             % "jena-core"               % "3.14.0",
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,11 @@ libraryDependencies ++= {
     // Add support for CSV.
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
 
-    // Import Apache Jena to read JSON-LD.
-    // "org.apache.jena"             % "jena-core"               % "3.14.0",
+    // Import Apache Jena to read ontologies.
+    "org.apache.jena"             % "jena-core"               % "3.14.0",
 
     // https://mvnrepository.com/artifact/org.apache.jena/jena-arq
-    // "org.apache.jena"             % "jena-arq"                % "3.14.0",
+    "org.apache.jena"             % "jena-arq"                % "3.14.0",
 
     // Add support for CSV
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
@@ -55,7 +55,7 @@ libraryDependencies ++= {
     // We need JDBC connection pooling so we can start new connections as needed.
     "org.apache.commons"          % "commons-dbcp2"           % "2.7.0",
 
-  // Add support for SQLite via JDBC
+    // Add support for SQLite via JDBC
     "org.xerial"                  % "sqlite-jdbc"             % "3.30.1",
 
     // Add support for calculating hashes for files.

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -109,7 +109,7 @@ object Filler extends App {
 
   scribe.info(
     f"""Out of ${rows.size} rows:
-       |  - $countExistingTerm rows (${countExistingTerm.toFloat/rows.size*100}%.2f%%) have existing terms
-       |  - $countNoMatch rows (${countNoMatch.toFloat/rows.size*100}%.2f%%) could not be matched
-       |  - $countMatch rows (${countMatch.toFloat/rows.size*100}%.2f%%) could be matched to this ontology""".stripMargin)
+       |  - $countExistingTerm rows (${countExistingTerm.toFloat/rows.size*100}%.2f%%) have existing terms.
+       |  - $countNoMatch rows (${countNoMatch.toFloat/rows.size*100}%.2f%%) could not be matched.
+       |  - $countMatch rows (${countMatch.toFloat/rows.size*100}%.2f%%) could be matched.""".stripMargin)
 }

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -1,0 +1,68 @@
+package org.renci.sssom
+
+import java.io.{File, FileWriter, OutputStreamWriter, PrintWriter}
+
+import com.github.tototoshi.csv.{CSVReader, CSVWriter, TSVFormat}
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
+
+import scala.io.Source
+
+/**
+  * org.renci.sssom.Filler is an application for filling in gaps in an [SSSOM file](https://github.com/OBOFoundry/SSSOM).
+  */
+object Filler extends App {
+
+  /**
+    * Command line configuration for Filler.
+    */
+  class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+    override def onError(e: Throwable): Unit =
+      e match {
+        case ScallopException(message) =>
+          printHelp
+          scribe.error(message)
+          System.exit(1)
+        case ex => super.onError(ex)
+      }
+
+    val version = getClass.getPackage.getImplementationVersion
+    version(s"Filler: add additional mappings to an existing SSSOM file (v$version)")
+
+    val inputFile: ScallopOption[File] = opt[File](descr = "The SSSOM file to fill in")
+    val outputFile: ScallopOption[File] = opt[File](descr = "The output file (in SSSOM format)")
+
+    val fromOntology: ScallopOption[List[File]] = opt[List[File]](
+      descr = "A list of ontologies to search for terms"
+    )
+
+    val fillPredicateId: ScallopOption[String] = opt[String](
+      descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch')"
+    )
+
+    verify()
+  }
+
+  // Parse command line arguments.
+  val conf = new Conf(args.toIndexedSeq)
+  val inputSource = if(conf.inputFile.isSupplied) Source.fromFile(conf.inputFile()) else Source.fromInputStream(System.in, "UTF-8")
+  val outputWriter = if(conf.outputFile.isSupplied) new PrintWriter(new FileWriter(conf.outputFile())) else new OutputStreamWriter(System.out)
+
+  // Read input as TSV.
+  val reader = CSVReader.open(inputSource)(new TSVFormat {})
+  val (headers, rows) = reader.allWithOrderedHeaders()
+
+  val writer = CSVWriter.open(outputWriter)(new TSVFormat {})
+  writer.writeRow(headers)
+  rows.map(row => {
+    // Should we fill in this row?
+    if(conf.fillPredicateId.isSupplied && row.getOrElse("predicate_id", "") == conf.fillPredicateId()) {
+      // Apply all the SSSOMRowFillers that are relevant here.
+      row
+    } else row
+  }).foreach(row => {
+    // Write out each row in the correct order.
+    writer.writeRow(headers.map(header => row.getOrElse(header, "")))
+  })
+  writer.close()
+}

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -35,7 +35,8 @@ object Filler extends App {
 
     val fromOntology: ScallopOption[List[File]] = opt[List[File]](
       descr = "A list of ontologies (as local RDF files) to search for terms",
-      short = 'o'
+      short = 'o',
+      default = Some(List[File]())
     )
 
     val fillLivestockBreedOntology: ScallopOption[Boolean] = opt[Boolean](
@@ -55,7 +56,7 @@ object Filler extends App {
   val outputWriter = if(conf.outputFile.isSupplied) new PrintWriter(new FileWriter(conf.outputFile())) else new OutputStreamWriter(System.out)
 
   // Build a list of SSSOMRowFillers that we need to apply here.
-  val rowFillers: Seq[SSSOMFiller] = (
+  val rowFillers: Seq[OntologyFiller] = (
     (if (conf.fillLivestockBreedOntology()) Some(new LivestockBreedOntologyFiller()) else None) +:
     conf.fromOntology().map(file => Some(OntologyFiller(file)))
   ).flatten

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -3,6 +3,7 @@ package org.renci.sssom
 import java.io.{File, FileWriter, OutputStreamWriter, PrintWriter}
 
 import com.github.tototoshi.csv.{CSVReader, CSVWriter, TSVFormat}
+import org.renci.sssom.ontologies.LivestockBreedOntologyFiller
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 import org.rogach.scallop.exceptions.ScallopException
 
@@ -32,8 +33,13 @@ object Filler extends App {
     val inputFile: ScallopOption[File] = opt[File](descr = "The SSSOM file to fill in")
     val outputFile: ScallopOption[File] = opt[File](descr = "The output file (in SSSOM format)")
 
-    val fromOntology: ScallopOption[List[File]] = opt[List[File]](
-      descr = "A list of ontologies to search for terms"
+    val fromOntology: ScallopOption[List[String]] = opt[List[String]](
+      descr = "A list of ontologies to search for terms",
+      short = 'o'
+    )
+
+    val fillLivestockBreedOntology: ScallopOption[Boolean] = opt[Boolean](
+      descr = "Fill terms from the Livestock Breed Ontology"
     )
 
     val fillPredicateId: ScallopOption[String] = opt[String](
@@ -48,6 +54,18 @@ object Filler extends App {
   val inputSource = if(conf.inputFile.isSupplied) Source.fromFile(conf.inputFile()) else Source.fromInputStream(System.in, "UTF-8")
   val outputWriter = if(conf.outputFile.isSupplied) new PrintWriter(new FileWriter(conf.outputFile())) else new OutputStreamWriter(System.out)
 
+  // Build a list of SSSOMRowFillers that we need to apply here.
+  val rowFillers: Seq[SSSOMFiller] = (
+    (if (conf.fillLivestockBreedOntology()) Some(new LivestockBreedOntologyFiller()) else None)
+    :: Nil
+    ).flatten
+  scribe.info(s"Active row fillers: ${rowFillers.mkString(", ")}")
+
+  if (rowFillers.isEmpty) {
+    scribe.error("No row fillers set! Use --help to see a list of possible filters.")
+    System.exit(1)
+  }
+
   // Read input as TSV.
   val reader = CSVReader.open(inputSource)(new TSVFormat {})
   val (headers, rows) = reader.allWithOrderedHeaders()
@@ -56,9 +74,20 @@ object Filler extends App {
   writer.writeRow(headers)
   rows.map(row => {
     // Should we fill in this row?
-    if(conf.fillPredicateId.isSupplied && row.getOrElse("predicate_id", "") == conf.fillPredicateId()) {
-      // Apply all the SSSOMRowFillers that are relevant here.
-      row
+    val subjectId = row.getOrElse("subject_id", "(none)")
+    val predicateId = row.getOrElse("predicate_id", "")
+    if(predicateId.isEmpty || (!conf.fillPredicateId.isSupplied || predicateId == conf.fillPredicateId())) {
+      scribe.info(s"Looking for a match for ${row.getOrElse("subject_id", "")} (${row.getOrElse("subject_label", "")})")
+      val optMatchResult = rowFillers.to(LazyList).flatMap(_.fillRow(row, headers)).headOption
+      if (optMatchResult.isEmpty) {
+        scribe.info(s"Could not fill subject ID $subjectId: no fillers matched")
+        row
+      } else {
+        val result = optMatchResult.head
+
+        scribe.info(s"Filled subject ID $subjectId with ${result.filler}")
+        result.result
+      }
     } else row
   }).foreach(row => {
     // Write out each row in the correct order.

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -44,7 +44,7 @@ object Filler extends App {
     )
 
     val fillPredicateId: ScallopOption[String] = opt[String](
-      descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch')"
+      descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
     )
 
     verify()
@@ -82,7 +82,7 @@ object Filler extends App {
     // Should we fill in this row?
     val subjectId = row.getOrElse("subject_id", "(none)")
     val predicateId = row.getOrElse("predicate_id", "")
-    if(predicateId.isEmpty || (!conf.fillPredicateId.isSupplied || predicateId == conf.fillPredicateId())) {
+    if(predicateId.isEmpty || (conf.fillPredicateId.isSupplied && predicateId == conf.fillPredicateId())) {
       scribe.debug(s"Looking for a match for ${row.getOrElse("subject_id", "")} (${row.getOrElse("subject_label", "")})")
       val optMatchResult = rowFillers.to(LazyList).flatMap(_.fillRow(row, headers)).headOption
       if (optMatchResult.isEmpty) {

--- a/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
+++ b/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
@@ -8,6 +8,7 @@ package org.renci.sssom
   * not provided in the input file may not be written into the output file.
   */
 abstract class SSSOMFiller {
+
   /**
     * Fill in the input row. The list of all headers is also provided.
     * @return None if this row could not be filled, and Some[Row] if it can.
@@ -16,13 +17,10 @@ abstract class SSSOMFiller {
 }
 
 object SSSOMFiller {
+
   /** A row is a map of column names to their values in this row. */
   type Row = Map[String, String]
 
   /** Wraps a result of a row filler operation. */
-  case class Result(
-    source: Row,
-    result: Row,
-    filler: SSSOMFiller
-  )
+  case class Result(source: Row, result: Row, filler: SSSOMFiller)
 }

--- a/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
+++ b/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
@@ -12,7 +12,7 @@ abstract class SSSOMFiller {
     * Fill in the input row. The list of all headers is also provided.
     * @return None if this row could not be filled, and Some[Row] if it can.
     */
-  def fillRow(row: SSSOMFiller.Row, headers: List[String]): Option[SSSOMFiller.Result]
+  def fillRow(row: SSSOMFiller.Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]]
 }
 
 object SSSOMFiller {

--- a/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
+++ b/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
@@ -1,0 +1,19 @@
+package org.renci.sssom
+
+/**
+  * A RowFiller can fill in a row in SSSOM format. It returns a copy of the row that was provided,
+  * but possibly with additional columns filled in.
+  *
+  * There are no guarantees as to the order in which the fields are returned; however, column names
+  * not provided in the input file may not be written into the output file.
+  */
+abstract class SSSOMRowFiller {
+  /** A row is a map of column names to their values in this row. */
+  type Row = Map[String, String]
+
+  /**
+    * Fill in the input row. The list of all headers is also provided.
+    * @return None if this row could not be filled, and Some[Row] if it can.
+    */
+  def fillRow(row: Row, headers: List[String]): Option[Row]
+}

--- a/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
+++ b/src/main/scala/org/renci/sssom/SSSOMRowFiller.scala
@@ -7,13 +7,22 @@ package org.renci.sssom
   * There are no guarantees as to the order in which the fields are returned; however, column names
   * not provided in the input file may not be written into the output file.
   */
-abstract class SSSOMRowFiller {
-  /** A row is a map of column names to their values in this row. */
-  type Row = Map[String, String]
-
+abstract class SSSOMFiller {
   /**
     * Fill in the input row. The list of all headers is also provided.
     * @return None if this row could not be filled, and Some[Row] if it can.
     */
-  def fillRow(row: Row, headers: List[String]): Option[Row]
+  def fillRow(row: SSSOMFiller.Row, headers: List[String]): Option[SSSOMFiller.Result]
+}
+
+object SSSOMFiller {
+  /** A row is a map of column names to their values in this row. */
+  type Row = Map[String, String]
+
+  /** Wraps a result of a row filler operation. */
+  case class Result(
+    source: Row,
+    result: Row,
+    filler: SSSOMFiller
+  )
 }

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -13,19 +13,23 @@ class LivestockBreedOntologyFiller extends OntologyFiller(new File("ontologies/l
   override def toString: String = "LivestockBreedOntologyFiller()"
 
   override def extractSubjectLabelsFromRow(row: Row): Seq[String] = {
-    val results = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").flatMap(label => {
-      // Try adding various breed labels at the end of it.
-      Seq(
-        label,
-        label.replaceAll(" cattle breed$", ""),
-        label.replaceAll(" cattle$", ""),
-        label.replaceAll(" sheep breed$", ""),
-        label.replaceAll(" sheep$", ""),
-        label.replaceAll(" horse breed$", ""),
-        label.replaceAll(" horse$", ""),
-        label.replaceAll(" pig$", "")
-      )
-    }).toSeq
+    val results = row
+      .getOrElse("subject_label", "")
+      .split("\\s*\\|\\s*")
+      .flatMap(label => {
+        // Try adding various breed labels at the end of it.
+        Seq(
+          label,
+          label.replaceAll(" cattle breed$", ""),
+          label.replaceAll(" cattle$", ""),
+          label.replaceAll(" sheep breed$", ""),
+          label.replaceAll(" sheep$", ""),
+          label.replaceAll(" horse breed$", ""),
+          label.replaceAll(" horse$", ""),
+          label.replaceAll(" pig$", "")
+        )
+      })
+      .toSeq
     scribe.info(s"Looking for subject label ${row.getOrElse("subject_label", "")}: $results")
     results
   }

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -1,0 +1,28 @@
+package org.renci.sssom.ontologies
+
+import org.renci.sssom.SSSOMFiller
+import org.renci.sssom.SSSOMFiller.Row
+
+/**
+  * Looks up terms in the Livestock Breed Ontology (http://bioportal.bioontology.org/ontologies/LBO).
+  * We need a custom handler for this because a lot of our terms are in the format "Jamaica Red cattle breed"
+  * while LBO has it in the format "Jamaica Red" (subclass of "cattle breed", http://purl.obolibrary.org/obo/LBO_0000144).
+  */
+class LivestockBreedOntologyFiller extends SSSOMFiller {
+  override def toString: String = "LivestockBreedOntologyFiller()"
+
+  /**
+    * Fill in the input row. The list of all headers is also provided.
+    *
+    * @return None if this row could not be filled, and Some[Row] if it can.
+    */
+  override def fillRow(row: Row, headers: List[String]): Option[SSSOMFiller.Result] = {
+    val subjectId = row.getOrElse("subject_id", "(none)")
+    val subjectLabels = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSet
+
+    val regex = "^(.*) cattle breed$".r
+    subjectLabels.to(LazyList).flatMap({
+      case regex(breedName) => Some(SSSOMFiller.Result(row, row, this))
+    }).headOption
+  }
+}

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -1,5 +1,7 @@
 package org.renci.sssom.ontologies
 
+import java.io.File
+
 import org.renci.sssom.SSSOMFiller
 import org.renci.sssom.SSSOMFiller.Row
 
@@ -8,21 +10,8 @@ import org.renci.sssom.SSSOMFiller.Row
   * We need a custom handler for this because a lot of our terms are in the format "Jamaica Red cattle breed"
   * while LBO has it in the format "Jamaica Red" (subclass of "cattle breed", http://purl.obolibrary.org/obo/LBO_0000144).
   */
-class LivestockBreedOntologyFiller extends SSSOMFiller {
+class LivestockBreedOntologyFiller extends OntologyFiller(new File("ontologies/lbo.owl")) {
   override def toString: String = "LivestockBreedOntologyFiller()"
 
-  /**
-    * Fill in the input row. The list of all headers is also provided.
-    *
-    * @return None if this row could not be filled, and Some[Row] if it can.
-    */
-  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
-    val subjectId = row.getOrElse("subject_id", "(none)")
-    val subjectLabels = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSet
 
-    val regex = "^(.*) cattle breed$".r
-    subjectLabels.to(LazyList).flatMap({
-      case regex(breedName) => Some(Seq(SSSOMFiller.Result(row, row, this)))
-    }).headOption
-  }
 }

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -2,7 +2,6 @@ package org.renci.sssom.ontologies
 
 import java.io.File
 
-import org.renci.sssom.SSSOMFiller
 import org.renci.sssom.SSSOMFiller.Row
 
 /**

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -13,5 +13,21 @@ import org.renci.sssom.SSSOMFiller.Row
 class LivestockBreedOntologyFiller extends OntologyFiller(new File("ontologies/lbo.owl")) {
   override def toString: String = "LivestockBreedOntologyFiller()"
 
-
+  override def extractSubjectLabelsFromRow(row: Row): Seq[String] = {
+    val results = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").flatMap(label => {
+      // Try adding various breed labels at the end of it.
+      Seq(
+        label,
+        label.replaceAll(" cattle breed$", ""),
+        label.replaceAll(" cattle$", ""),
+        label.replaceAll(" sheep breed$", ""),
+        label.replaceAll(" sheep$", ""),
+        label.replaceAll(" horse breed$", ""),
+        label.replaceAll(" horse$", ""),
+        label.replaceAll(" pig$", "")
+      )
+    }).toSeq
+    scribe.info(s"Looking for subject label ${row.getOrElse("subject_label", "")}: $results")
+    results
+  }
 }

--- a/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/LivestockBreedOntologyFiller.scala
@@ -16,13 +16,13 @@ class LivestockBreedOntologyFiller extends SSSOMFiller {
     *
     * @return None if this row could not be filled, and Some[Row] if it can.
     */
-  override def fillRow(row: Row, headers: List[String]): Option[SSSOMFiller.Result] = {
+  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
     val subjectId = row.getOrElse("subject_id", "(none)")
     val subjectLabels = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSet
 
     val regex = "^(.*) cattle breed$".r
     subjectLabels.to(LazyList).flatMap({
-      case regex(breedName) => Some(SSSOMFiller.Result(row, row, this))
+      case regex(breedName) => Some(Seq(SSSOMFiller.Result(row, row, this)))
     }).headOption
   }
 }

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
@@ -1,74 +1,22 @@
 package org.renci.sssom.ontologies
 
 import java.io.File
-import java.net.{HttpURLConnection, URI, URL}
+import java.net.{HttpURLConnection, URL}
 
-import org.apache.commons.dbcp2.DriverManagerConnectionFactory
-import org.apache.jena.graph.impl.LiteralLabel
 import org.apache.jena.graph.{Graph, Node, NodeFactory, Triple}
 import org.apache.jena.ontology.OntModelSpec
-import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.riot.system.StreamRDF
-import org.apache.jena.riot.{Lang, RDFParser}
-import org.apache.jena.sparql.core.Quad
+import org.apache.jena.rdf.model.{ModelFactory, Resource}
+import org.apache.jena.util.iterator.ExtendedIterator
 import org.apache.jena.vocabulary.RDFS
 import org.renci.sssom.SSSOMFiller
 import org.renci.sssom.SSSOMFiller.Row
 
-import scala.collection.JavaConverters._
-import scala.util.Try
+import scala.jdk.CollectionConverters._
 
 /**
   * A generic class for filling in SSSOM files with terms from an ontology.
   */
 case class OntologyFiller(ontology: File) extends SSSOMFiller {
-  /**
-    * When the class is initialized, it should open the ontology to look into it.
-    * However, we need to store it in an SQLite database for quicker access.
-    */
-  /*
-  lazy val sqliteDb: DriverManagerConnectionFactory = new DriverManagerConnectionFactory(
-    "jdbc:sqlite:./ontologies.sqlite"
-  )
-
-  val conn = sqliteDb.createConnection()
-  val results = Try {
-    val checkCount = conn.prepareStatement("SELECT COUNT(*) AS cnt FROM ontologies WHERE url=?")
-    checkCount.setString(1, url.toString)
-    checkCount.executeQuery()
-  }
-  val rowsFromDb = results.map(_.getInt(1)).getOrElse(-1)
-  conn.close()
-
-  if (rowsFromDb <= 0) {
-    scribe.info(s"No labels from ontology $ontology in ontologies SQLite table, regenerating.")
-
-    val exampleURL = "http://example.org/"
-    val exampleGraph = NodeFactory.createURI(exampleURL.toString)
-
-    RDFParser.source(ontology.getAbsolutePath).lang(Lang.RDFXML).parse(new StreamRDF {
-      override def start(): Unit = {}
-
-      override def triple(triple: Triple): Unit = quad(new Quad(exampleGraph, triple))
-
-      override def quad(quad: Quad): Unit = {
-        if (quad.getPredicate.getURI.equals(RDFS.label.getURI)) {
-          val subject: URI = new URI(quad.getSubject.getURI)
-          val label: LiteralLabel = quad.getObject.getLiteral
-          val labelLanguage: String = label.language()
-          scribe.debug(s"Found label: ${subject} has label ${label.getValue}@$labelLanguage.")
-        }
-      }
-
-      override def base(base: String): Unit = {}
-
-      override def prefix(prefix: String, iri: String): Unit = {}
-
-      override def finish(): Unit = {}
-    })
-    scribe.info("Completed RDFParser")
-  }*/
-
   val owlModelSpec = new OntModelSpec( OntModelSpec.OWL_LITE_MEM )
   val owlModel = ModelFactory.createOntologyModel(owlModelSpec)
   owlModel.read(ontology.getAbsolutePath)
@@ -76,40 +24,48 @@ case class OntologyFiller(ontology: File) extends SSSOMFiller {
   scribe.info(s"Loaded ontology $ontology containing ${owlModel.getGraph.size()} triples.")
 
   /**
-    * Fill in the input row. The list of all headers is also provided.
-    *
-    * @return None if this row could not be filled, and Some[Row] if it can.
+    * Extract subject label for a particular row
     */
-  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
-    val subjectId = row.getOrElse("subject_id", "")
-    val subjectLabels = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSeq
+  def extractSubjectLabelsFromRow(row: Row): Seq[String] = {
+    row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSeq
+  }
 
+  /**
+    * Find all subjects that match a particular row.
+    */
+  def identifyResultsForRow(row: Row): Seq[SSSOMFiller.Result] = {
     val predicates: Set[Node] = Set(
       RDFS.label.asNode(),
       NodeFactory.createURI("http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym")
     )
 
-    val results = subjectLabels flatMap { subjectLabel =>
-      ontologyGraph.find(null, null, NodeFactory.createLiteral(subjectLabel))
-        .filterKeep(triple => predicates.contains(triple.getPredicate))
-        .mapWith(triple => {
-          scribe.info(s"Found match! Subject label $subjectLabel mapped to triple $triple")
+    val triples = for {
+      subjectLabel <- extractSubjectLabelsFromRow(row)
+      triple <- ontologyGraph.find(null, null, NodeFactory.createLiteral(subjectLabel)).asScala
+        if predicates.contains(triple.getPredicate)
+    } yield triple
 
-          val subjectURI = triple.getSubject.getURI
-          val subjectLabels = ontologyGraph.find(triple.getSubject, RDFS.label.asNode(), null).asScala.map(_.getObject.toString(false))
+    triples.map(triple => {
+      val subject = triple.getSubject
+      val subjectURI = subject.getURI
+      val subjectLabels = ontologyGraph.find(subject, RDFS.label.asNode(), null).asScala.map(_.getObject.toString(false))
+      SSSOMFiller.Result(
+        row,
+        row + ("predicate_id" -> subjectURI)
+          + ("predicate_label" -> subjectLabels.mkString("|"))
+          + ("comment" -> s"Ontology $ontology contains triple asserting $triple"),
+        this
+      )
+    })
+  }
 
-          val result = SSSOMFiller.Result(
-            row,
-            row + ("predicate_id" -> subjectURI)
-              + ("predicate_label" -> subjectLabels.mkString("|"))
-              + ("comment" -> s"Ontology $ontology contains triple asserting $triple"),
-            this
-          )
-          scribe.info(s"Result: $result")
-          result
-        }).asScala
-    }
-
+  /**
+    * Fill in the input row. The list of all headers is also provided.
+    *
+    * @return None if this row could not be filled, and Some[Row] if it can.
+    */
+  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
+    val results = identifyResultsForRow(row)
     if (results.isEmpty) None else Some(results)
   }
 }

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
@@ -1,0 +1,128 @@
+package org.renci.sssom.ontologies
+
+import java.io.File
+import java.net.{HttpURLConnection, URI, URL}
+
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory
+import org.apache.jena.graph.impl.LiteralLabel
+import org.apache.jena.graph.{Graph, Node, NodeFactory, Triple}
+import org.apache.jena.ontology.OntModelSpec
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.system.StreamRDF
+import org.apache.jena.riot.{Lang, RDFParser}
+import org.apache.jena.sparql.core.Quad
+import org.apache.jena.vocabulary.RDFS
+import org.renci.sssom.SSSOMFiller
+import org.renci.sssom.SSSOMFiller.Row
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/**
+  * A generic class for filling in SSSOM files with terms from an ontology.
+  */
+case class OntologyFiller(ontology: File) extends SSSOMFiller {
+  /**
+    * When the class is initialized, it should open the ontology to look into it.
+    * However, we need to store it in an SQLite database for quicker access.
+    */
+  /*
+  lazy val sqliteDb: DriverManagerConnectionFactory = new DriverManagerConnectionFactory(
+    "jdbc:sqlite:./ontologies.sqlite"
+  )
+
+  val conn = sqliteDb.createConnection()
+  val results = Try {
+    val checkCount = conn.prepareStatement("SELECT COUNT(*) AS cnt FROM ontologies WHERE url=?")
+    checkCount.setString(1, url.toString)
+    checkCount.executeQuery()
+  }
+  val rowsFromDb = results.map(_.getInt(1)).getOrElse(-1)
+  conn.close()
+
+  if (rowsFromDb <= 0) {
+    scribe.info(s"No labels from ontology $ontology in ontologies SQLite table, regenerating.")
+
+    val exampleURL = "http://example.org/"
+    val exampleGraph = NodeFactory.createURI(exampleURL.toString)
+
+    RDFParser.source(ontology.getAbsolutePath).lang(Lang.RDFXML).parse(new StreamRDF {
+      override def start(): Unit = {}
+
+      override def triple(triple: Triple): Unit = quad(new Quad(exampleGraph, triple))
+
+      override def quad(quad: Quad): Unit = {
+        if (quad.getPredicate.getURI.equals(RDFS.label.getURI)) {
+          val subject: URI = new URI(quad.getSubject.getURI)
+          val label: LiteralLabel = quad.getObject.getLiteral
+          val labelLanguage: String = label.language()
+          scribe.debug(s"Found label: ${subject} has label ${label.getValue}@$labelLanguage.")
+        }
+      }
+
+      override def base(base: String): Unit = {}
+
+      override def prefix(prefix: String, iri: String): Unit = {}
+
+      override def finish(): Unit = {}
+    })
+    scribe.info("Completed RDFParser")
+  }*/
+
+  val owlModelSpec = new OntModelSpec( OntModelSpec.OWL_LITE_MEM )
+  val owlModel = ModelFactory.createOntologyModel(owlModelSpec)
+  owlModel.read(ontology.getAbsolutePath)
+  val ontologyGraph: Graph = owlModel.getGraph
+  scribe.info(s"Loaded ontology $ontology containing ${owlModel.getGraph.size()} triples.")
+
+  /**
+    * Fill in the input row. The list of all headers is also provided.
+    *
+    * @return None if this row could not be filled, and Some[Row] if it can.
+    */
+  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
+    val subjectId = row.getOrElse("subject_id", "")
+    val subjectLabels = row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSeq
+
+    val predicates: Set[Node] = Set(
+      RDFS.label.asNode(),
+      NodeFactory.createURI("http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym")
+    )
+
+    val results = subjectLabels flatMap { subjectLabel =>
+      ontologyGraph.find(null, null, NodeFactory.createLiteral(subjectLabel))
+        .filterKeep(triple => predicates.contains(triple.getPredicate))
+        .mapWith(triple => {
+          scribe.info(s"Found match! Subject label $subjectLabel mapped to triple $triple")
+
+          val subjectURI = triple.getSubject.getURI
+          val subjectLabels = ontologyGraph.find(triple.getSubject, RDFS.label.asNode(), null).asScala.map(_.getObject.toString(false))
+
+          val result = SSSOMFiller.Result(
+            row,
+            row + ("predicate_id" -> subjectURI)
+              + ("predicate_label" -> subjectLabels.mkString("|"))
+              + ("comment" -> s"Ontology $ontology contains triple asserting $triple"),
+            this
+          )
+          scribe.info(s"Result: $result")
+          result
+        }).asScala
+    }
+
+    if (results.isEmpty) None else Some(results)
+  }
+}
+
+object OntologyFiller {
+  def getRedirectedURL(sourceURL: URL): URL = {
+    // Find out where this URL redirects to.
+    val conn = sourceURL.openConnection().asInstanceOf[HttpURLConnection]
+    conn.setInstanceFollowRedirects(false)
+    if (conn.getResponseCode == HttpURLConnection.HTTP_MOVED_TEMP || conn.getResponseCode == HttpURLConnection.HTTP_MOVED_PERM) {
+      val location = conn.getHeaderField("Location")
+      if (location == null) throw new RuntimeException(s"Redirect without 'Location' provided: ${conn}")
+      else getRedirectedURL(new URL(location))
+    } else sourceURL
+  }
+}


### PR DESCRIPTION
This PR adds support for adding terms to an existing SSSOM file by looking them up in a particular ontology. It does this by creating a new executable class: Filler. Filler reads an SSSOM file as input, adds mappings based on the command line arguments provided, and writes them out to a new file. The only Fillers currently supported are the OntologyFiller, which adds terms from the specified ontology (in a local OWL file), and the LivestockBreedOntologyFiller, which is designed to modify terms so that they can matched against the LBO. Multiple ontologies can be specified.

This is very hacky code and might eventually benefit from being separated into its own repository, but it's probably fine in here for now.