### PR TITLE
Added OntologyLookupServiceFiller

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,9 @@ addCommandAlias(
   "; compile:scalafix --check ; test:scalafix --check"
 )
 
+// Add additional repositories.
+resolvers += "EBI Repository" at "https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/"
+
 // Library dependencies.
 libraryDependencies ++= {
   Seq(
@@ -51,6 +54,9 @@ libraryDependencies ++= {
 
     // Add support for CSV
     "com.github.tototoshi"        %% "scala-csv"              % "1.3.6",
+
+    // Add API for accessing the Ontology Lookup Service.
+    "uk.ac.ebi.pride.utilities"   % "ols-client"              % "2.11",
 
     // We need JDBC connection pooling so we can start new connections as needed.
     "org.apache.commons"          % "commons-dbcp2"           % "2.7.0",

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -3,7 +3,7 @@ package org.renci.sssom
 import java.io.{File, FileWriter, OutputStreamWriter, PrintWriter}
 
 import com.github.tototoshi.csv.{CSVReader, CSVWriter, TSVFormat}
-import org.renci.sssom.ontologies.{LivestockBreedOntologyFiller, OntologyFiller}
+import org.renci.sssom.ontologies.{LivestockBreedOntologyFiller, OntologyFiller, OntologyLookupServiceFiller}
 import org.rogach.scallop.exceptions.ScallopException
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
@@ -43,6 +43,10 @@ object Filler extends App {
       descr = "Fill terms from the Livestock Breed Ontology"
     )
 
+    val fillFromOls: ScallopOption[Boolean] = opt[Boolean](
+      descr = "Fill terms from the Ontology Lookup Service"
+    )
+
     val fillPredicateId: ScallopOption[String] = opt[String](
       descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
     )
@@ -56,7 +60,8 @@ object Filler extends App {
   val outputWriter = if(conf.outputFile.isSupplied) new PrintWriter(new FileWriter(conf.outputFile())) else new OutputStreamWriter(System.out)
 
   // Build a list of SSSOMRowFillers that we need to apply here.
-  val rowFillers: Seq[OntologyFiller] = (
+  val rowFillers: Seq[SSSOMFiller] = (
+    (if (conf.fillFromOls()) Some(new OntologyLookupServiceFiller()) else None) +:
     (if (conf.fillLivestockBreedOntology()) Some(new LivestockBreedOntologyFiller()) else None) +:
     conf.fromOntology().map(file => Some(OntologyFiller(file)))
   ).flatten

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -114,7 +114,7 @@ object Filler extends App {
 
   scribe.info(
     f"""Out of ${rows.size} rows:
-       |  - $countExistingTerm rows (${countExistingTerm.toFloat/rows.size*100}%.2f%%) have existing terms
-       |  - $countNoMatch rows (${countNoMatch.toFloat/rows.size*100}%.2f%%) could not be matched
-       |  - $countMatch rows (${countMatch.toFloat/rows.size*100}%.2f%%) could be matched to this ontology""".stripMargin)
+       |  - $countExistingTerm rows (${countExistingTerm.toFloat/rows.size*100}%.2f%%) have existing terms.
+       |  - $countNoMatch rows (${countNoMatch.toFloat/rows.size*100}%.2f%%) could not be matched.
+       |  - $countMatch rows (${countMatch.toFloat/rows.size*100}%.2f%%) could be matched.""".stripMargin)
 }

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -3,7 +3,11 @@ package org.renci.sssom
 import java.io.{File, FileWriter, OutputStreamWriter, PrintWriter}
 
 import com.github.tototoshi.csv.{CSVReader, CSVWriter, TSVFormat}
-import org.renci.sssom.ontologies.{LivestockBreedOntologyFiller, OntologyFiller, OntologyLookupServiceFiller}
+import org.renci.sssom.ontologies.{
+  LivestockBreedOntologyFiller,
+  OntologyFiller,
+  OntologyLookupServiceFiller
+}
 import org.rogach.scallop.exceptions.ScallopException
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
@@ -42,12 +46,11 @@ object Filler extends App {
     val fillLivestockBreedOntology: ScallopOption[Boolean] =
       opt[Boolean](descr = "Fill terms from the Livestock Breed Ontology")
 
-    val fillFromOls: ScallopOption[Boolean] = opt[Boolean](
-      descr = "Fill terms from the Ontology Lookup Service"
-    )
+    val fillFromOls: ScallopOption[Boolean] =
+      opt[Boolean](descr = "Fill terms from the Ontology Lookup Service")
 
-    val fillPredicateId: ScallopOption[String] = opt[String](
-      descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
+    val fillPredicateId: ScallopOption[String] = opt[String](descr =
+      "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
     )
 
     verify()
@@ -65,7 +68,7 @@ object Filler extends App {
   // Build a list of SSSOMRowFillers that we need to apply here.
   val rowFillers: Seq[SSSOMFiller] = (
     (if (conf.fillFromOls()) Some(new OntologyLookupServiceFiller()) else None) +:
-    (if (conf.fillLivestockBreedOntology()) Some(new LivestockBreedOntologyFiller()) else None) +:
+      (if (conf.fillLivestockBreedOntology()) Some(new LivestockBreedOntologyFiller()) else None) +:
       conf.fromOntology().map(file => Some(OntologyFiller(file)))
   ).flatten
   scribe.info(s"Active row fillers: ${rowFillers.mkString(", ")}")

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -50,10 +50,6 @@ object Filler extends App {
       descr = "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
     )
 
-    val fillPredicateId: ScallopOption[String] = opt[String](descr =
-      "Choose the predicate ID to fill in (e.g. 'skos:narrowMatch') in addition to blank rows"
-    )
-
     verify()
   }
 

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
@@ -3,7 +3,7 @@ package org.renci.sssom.ontologies
 import java.io.File
 import java.net.{HttpURLConnection, URL}
 
-import org.apache.jena.graph.{Graph, Node, NodeFactory}
+import org.apache.jena.graph.{Graph, Node, NodeFactory, Triple}
 import org.apache.jena.ontology.OntModelSpec
 import org.apache.jena.rdf.model.{ModelFactory, Resource}
 import org.apache.jena.sparql.graph.GraphFactory

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
@@ -6,6 +6,7 @@ import java.net.{HttpURLConnection, URL}
 import org.apache.jena.graph.{Graph, Node, NodeFactory, Triple}
 import org.apache.jena.ontology.OntModelSpec
 import org.apache.jena.rdf.model.{ModelFactory, Resource}
+import org.apache.jena.sparql.graph.GraphFactory
 import org.apache.jena.util.iterator.ExtendedIterator
 import org.apache.jena.vocabulary.RDFS
 import org.renci.sssom.SSSOMFiller
@@ -16,12 +17,35 @@ import scala.jdk.CollectionConverters._
 /**
   * A generic class for filling in SSSOM files with terms from an ontology.
   */
-case class OntologyFiller(ontology: File) extends SSSOMFiller {
+case class OntologyFiller(
+                           ontology: File,
+                           predicates: Set[Node] = Set(
+                             RDFS.label.asNode(),
+                             NodeFactory.createURI("http://www.geneontology.org/formats/oboInOwl#hasExactSynonym")
+                           )
+                         ) extends SSSOMFiller {
   val owlModelSpec = new OntModelSpec( OntModelSpec.OWL_LITE_MEM )
   val owlModel = ModelFactory.createOntologyModel(owlModelSpec)
   owlModel.read(ontology.getAbsolutePath)
   val ontologyGraph: Graph = owlModel.getGraph
   scribe.info(s"Loaded ontology $ontology containing ${owlModel.getGraph.size()} triples.")
+
+  // Add an 'rdfs:label' in lowercase so we don't have to worry about casing issues.
+  val indexes = GraphFactory.createDefaultGraph()
+  ontologyGraph.find()
+    .filterKeep(tr => predicates.contains(tr.getPredicate))
+    .forEachRemaining(tr => {
+      val lowercased = tr.getObject.getLiteralLexicalForm.toLowerCase()
+      // scribe.info(s"Translated label '${tr.getObject.getLiteralLexicalForm}' to '${lowercased}'")
+
+      indexes.add(new Triple(
+        tr.getSubject,
+        RDFS.label.asNode(),
+        NodeFactory.createLiteral(lowercased)
+      ))
+    })
+  indexes.find().forEachRemaining(tr => ontologyGraph.add(tr))
+  scribe.info(s"Added consistent lowercase labels.")
 
   /**
     * Extract subject label for a particular row
@@ -34,14 +58,9 @@ case class OntologyFiller(ontology: File) extends SSSOMFiller {
     * Find all subjects that match a particular row.
     */
   def identifyResultsForRow(row: Row): Seq[SSSOMFiller.Result] = {
-    val predicates: Set[Node] = Set(
-      RDFS.label.asNode(),
-      NodeFactory.createURI("http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym")
-    )
-
     val triples = for {
-      subjectLabel <- extractSubjectLabelsFromRow(row)
-      triple <- ontologyGraph.find(null, null, NodeFactory.createLiteral(subjectLabel)).asScala
+      subjectLabel <- extractSubjectLabelsFromRow(row).distinct
+      triple <- ontologyGraph.find(null, null, NodeFactory.createLiteral(subjectLabel.toLowerCase)).asScala
         if predicates.contains(triple.getPredicate)
     } yield triple
 
@@ -51,9 +70,13 @@ case class OntologyFiller(ontology: File) extends SSSOMFiller {
       val subjectLabels = ontologyGraph.find(subject, RDFS.label.asNode(), null).asScala.map(_.getObject.toString(false))
       SSSOMFiller.Result(
         row,
-        row + ("predicate_id" -> subjectURI)
-          + ("predicate_label" -> subjectLabels.mkString("|"))
-          + ("comment" -> s"Ontology $ontology contains triple asserting $triple"),
+        row + ("object_id" -> subjectURI)
+          + ("object_label" -> subjectLabels.mkString("|"))
+          + ("predicate_id" -> "skos:exactMatch")
+          + ("predicate_label" -> "The subject and the object can, with a high degree of confidence, be used interchangeably across a wide range of information retrieval applications.")
+          + ("comment" -> s"Ontology $ontology contains triple asserting $triple")
+          + ("match_type" -> "SSSOMC:Complex")
+          + ("mapping_set_id" -> ontology.getName),
         this
       )
     })

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
@@ -1,0 +1,99 @@
+package org.renci.sssom.ontologies
+
+import java.io.File
+import java.util
+
+import org.apache.jena.graph.{Graph, Node, NodeFactory}
+import org.apache.jena.ontology.OntModelSpec
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.vocabulary.RDFS
+import org.renci.sssom.SSSOMFiller
+import org.renci.sssom.SSSOMFiller.Row
+
+import scala.jdk.CollectionConverters._
+import uk.ac.ebi.pride.utilities.ols.web.service.client.OLSClient
+import uk.ac.ebi.pride.utilities.ols.web.service.config.OLSWsConfigProd
+import uk.ac.ebi.pride.utilities.ols.web.service.model.Term
+
+
+/**
+  * A generic class for filling in SSSOM files with terms from the Ontology Lookup Service (OLS).
+  *
+  * We use the API at https://www.ebi.ac.uk/ols/docs/api via the OLS Client
+  * (https://github.com/PRIDE-Utilities/ols-client)
+  */
+class OntologyLookupServiceFiller extends SSSOMFiller {
+  val client = new OLSClient(new OLSWsConfigProd())
+  scribe.info(s"Loaded OLS Client with config: ${client.getConfig.toString}.")
+
+  /**
+    * Extract subject label for a particular row
+    */
+  def extractSubjectLabelsFromRow(row: Row): Seq[String] = {
+    row.getOrElse("subject_label", "").split("\\s*\\|\\s*").toSeq
+  }
+
+  /**
+    * Find all subjects that match a particular row.
+    */
+  def identifyResultsForRow(row: Row): Seq[SSSOMFiller.Result] = {
+    val labels = extractSubjectLabelsFromRow(row)
+
+    // Do exact matches.
+    val exactMatches = for {
+      label <- labels
+      term <- {
+        val result: util.List[Term] = client.getExactTermsByName(label, null)
+        if (result == null) Seq() else result.asScala.distinctBy(_.getIri.getIdentifier)
+      }
+    } yield SSSOMFiller.Result(
+      row,
+      row + ("object_id" -> term.getIri.getIdentifier)
+        + ("object_label" -> term.getLabel)
+        + ("predicate_id" -> "skos:exactMatch")
+        + ("predicate_label" -> "The subject and the object can, with a high degree of confidence, be used interchangeably across a wide range of information retrieval applications.")
+        + ("comment" -> s"The EBI Ontology Lookup Service suggested this term as an exact match for label '$label'.")
+        + ("match_type" -> "SSSOMC:Complex")
+        + ("mapping_set_id" -> "https://www.ebi.ac.uk/ols/"),
+      this
+    )
+
+    exactMatches
+
+    // If we don't have exact matches, do a non-exact match.
+    /*
+    if (exactMatches.nonEmpty) exactMatches else {
+      val approxMatches = for {
+        label <- labels
+        term <- {
+          val result: util.List[Term] = client.getTermsByName(label, null, false)
+          if (result == null) Seq() else result.asScala.distinctBy(_.getIri.getIdentifier)
+        }
+      } yield SSSOMFiller.Result(
+        row,
+        row + ("object_id" -> term.getIri.getIdentifier)
+          + ("object_label" -> term.getLabel)
+          + ("predicate_id" -> "skos:relatedMatch")
+          + ("predicate_label" -> "The subject and the object are associated in some unspecified way.")
+          + ("comment" -> s"The EBI Ontology Lookup Service suggested this term as a non-exact match for label '$label'.")
+          + ("match_type" -> "SSSOMC:Complex")
+          + ("mapping_set_id" -> "https://www.ebi.ac.uk/ols/"),
+        this
+      )
+
+      approxMatches
+    }*/
+  }
+
+  /**
+    * Fill in the input row. The list of all headers is also provided.
+    *
+    * @return None if this row could not be filled, and Some[Row] if it can.
+    */
+  override def fillRow(row: Row, headers: List[String]): Option[Seq[SSSOMFiller.Result]] = {
+    val results = identifyResultsForRow(row)
+    if (results.isEmpty) None else Some(results)
+  }
+}
+
+

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
@@ -1,12 +1,7 @@
 package org.renci.sssom.ontologies
 
-import java.io.File
 import java.util
 
-import org.apache.jena.graph.{Graph, Node, NodeFactory}
-import org.apache.jena.ontology.OntModelSpec
-import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.vocabulary.RDFS
 import org.renci.sssom.SSSOMFiller
 import org.renci.sssom.SSSOMFiller.Row
 
@@ -14,7 +9,6 @@ import scala.jdk.CollectionConverters._
 import uk.ac.ebi.pride.utilities.ols.web.service.client.OLSClient
 import uk.ac.ebi.pride.utilities.ols.web.service.config.OLSWsConfigProd
 import uk.ac.ebi.pride.utilities.ols.web.service.model.Term
-
 
 /**
   * A generic class for filling in SSSOM files with terms from the Ontology Lookup Service (OLS).
@@ -95,5 +89,3 @@ class OntologyLookupServiceFiller extends SSSOMFiller {
     if (results.isEmpty) None else Some(results)
   }
 }
-
-


### PR DESCRIPTION
Adds an OntologyLookupServiceFiller that attempts to use EBI's [Ontology Lookup Service](https://www.ebi.ac.uk/ols/) to fill in missing mappings.

Also fixes OntologyFiller so that it performs case-insensitive searches of ontology terms.