### PR TITLE
Optimizations and bug fixes

### DIFF
--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -90,6 +90,7 @@ object Filler extends App {
   val writer = CSVWriter.open(outputWriter)(new TSVFormat {})
   writer.writeRow(headers)
   rows
+    .to(LazyList)
     .flatMap(row => {
       // Should we fill in this row?
       val subjectId = row.getOrElse("subject_id", "(none)")

--- a/src/main/scala/org/renci/sssom/Filler.scala
+++ b/src/main/scala/org/renci/sssom/Filler.scala
@@ -73,6 +73,18 @@ object Filler extends App {
   ).flatten
   scribe.info(s"Active row fillers: ${rowFillers.mkString(", ")}")
 
+  val predicateIds: Seq[String] = if (!conf.fillPredicateId.isSupplied) {
+    scribe.info("No predicate IDs supplied: only rows missing predicate IDs will be fixed.")
+    Seq()
+  } else {
+    val predicates = conf.fillPredicateId()
+      .split("\\s*,\\s*")
+      .map(_.replaceAll("^\\s*'(.*)'\\s*$", "$1"))
+
+    scribe.info(s"Predicate IDs being filled: ${predicates}")
+    predicates
+  }
+
   if (rowFillers.isEmpty) {
     scribe.error("No row fillers set! Use --help to see a list of possible filters.")
     System.exit(1)
@@ -96,8 +108,7 @@ object Filler extends App {
       val subjectId = row.getOrElse("subject_id", "(none)")
       val predicateId = row.getOrElse("predicate_id", "")
       if (
-        predicateId.isEmpty || (conf.fillPredicateId.isSupplied && predicateId == conf
-          .fillPredicateId())
+        predicateId.isEmpty || predicateIds.contains(predicateId)
       ) {
         scribe.debug(
           s"Looking for a match for ${row.getOrElse("subject_id", "")} (${row.getOrElse("subject_label", "")})"

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyFiller.scala
@@ -76,7 +76,7 @@ case class OntologyFiller(
           + ("predicate_id" -> "skos:exactMatch")
           + ("predicate_label" -> "The subject and the object can, with a high degree of confidence, be used interchangeably across a wide range of information retrieval applications.")
           + ("comment" -> s"Ontology $ontology contains triple asserting $triple")
-          + ("match_type" -> "SSSOMC:Complex")
+          + ("match_type" -> "http://purl.org/sssom/type/Complex")
           + ("mapping_set_id" -> ontology.getName),
         this
       )

--- a/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
+++ b/src/main/scala/org/renci/sssom/ontologies/OntologyLookupServiceFiller.scala
@@ -47,7 +47,7 @@ class OntologyLookupServiceFiller extends SSSOMFiller {
         + ("predicate_id" -> "skos:exactMatch")
         + ("predicate_label" -> "The subject and the object can, with a high degree of confidence, be used interchangeably across a wide range of information retrieval applications.")
         + ("comment" -> s"The EBI Ontology Lookup Service suggested this term as an exact match for label '$label'.")
-        + ("match_type" -> "SSSOMC:Complex")
+        + ("match_type" -> "http://purl.org/sssom/type/Complex")
         + ("mapping_set_id" -> "https://www.ebi.ac.uk/ols/"),
       this
     )
@@ -70,7 +70,7 @@ class OntologyLookupServiceFiller extends SSSOMFiller {
           + ("predicate_id" -> "skos:relatedMatch")
           + ("predicate_label" -> "The subject and the object are associated in some unspecified way.")
           + ("comment" -> s"The EBI Ontology Lookup Service suggested this term as a non-exact match for label '$label'.")
-          + ("match_type" -> "SSSOMC:Complex")
+          + ("match_type" -> "http://purl.org/sssom/type/Complex")
           + ("mapping_set_id" -> "https://www.ebi.ac.uk/ols/"),
         this
       )

--- a/src/main/scala/org/renci/umls/db/DbConcepts.scala
+++ b/src/main/scala/org/renci/umls/db/DbConcepts.scala
@@ -16,6 +16,7 @@ import scala.io.Source
 /** A wrapper for RRFConcepts that uses SQLite */
 class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     extends RRFConcepts(file, filename) {
+  val cacheTimePeriod = None // Some(2.hours)
   implicit val halfMapSeqCache = CaffeineCache[Seq[HalfMap]]
   implicit val halfMapSetCache = CaffeineCache[Set[HalfMap]]
   implicit val stringSetCache = CaffeineCache[Set[String]]
@@ -125,19 +126,19 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
 
   /** Return all known labels for a set of concepts */
   def getLabelsForCodes(source: String, ids: Seq[String]): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       ids.flatMap(getLabelsForCode(source, _)).toSet
     }
 
   /** Return all known labels for a single concept */
   def getLabelsForCode(source: String, id: String): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       getHalfMapsForCodes(source, Seq(id)).map(_.label).toSet
     }
 
   /** Return all known labels for a single CUI */
   def getLabelsForCUI(cui: String): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       getHalfMapsByCUIs(Set(cui)).map(_.label).toSet
     }
 
@@ -151,7 +152,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     * @return A Seq of HalfMaps for the provided identifiers in the provided source.
     */
   def getHalfMapsForCodes(source: String, ids: Seq[String]): Seq[HalfMap] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       // Retrieve all the fromIds.
       val conn = db.createConnection()
       if (ids.isEmpty) {
@@ -286,7 +287,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
 
   // Look up maps by CUIs.
   def getHalfMapsByCUIs(cuis: Set[String], toSource: String): Seq[HalfMap] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (cuis.isEmpty) return Seq()
 
       val conn = db.createConnection()
@@ -317,7 +318,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     }
 
   def getHalfMapsByCUIs(cuis: Set[String]): Seq[HalfMap] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (cuis.isEmpty) return Seq()
 
       val conn = db.createConnection()
@@ -348,7 +349,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
 
   // Get the CUIs for given AUIs.
   def getCUIsForAUI(auis: Seq[String]): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (auis.isEmpty) return Set()
 
       val conn = db.createConnection()
@@ -371,7 +372,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     }
 
   def getAUIsForCUIs(cuis: Seq[String]): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (cuis.isEmpty) return Set()
 
       val conn = db.createConnection()
@@ -394,7 +395,7 @@ class DbConcepts(db: ConnectionFactory, file: File, filename: String)
     }
 
   def getCUIsForCodes(source: String, ids: Seq[String]): Map[String, Seq[String]] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (ids.isEmpty) return Map.empty
 
       val conn = db.createConnection()

--- a/src/main/scala/org/renci/umls/db/DbHierarchy.scala
+++ b/src/main/scala/org/renci/umls/db/DbHierarchy.scala
@@ -32,6 +32,7 @@ case class HierarchyEntry(
 class DbHierarchy(db: ConnectionFactory, file: File, filename: String)
     extends RRFHierarchy(file, filename) {
 
+  val cacheTimePeriod = None // Some(2.hours)
   implicit val stringSetCache = CaffeineCache[Set[String]]
 
   /** The name of the table used to store this information. We include the SHA-256 hash so we reload it if it changes. */
@@ -97,7 +98,7 @@ class DbHierarchy(db: ConnectionFactory, file: File, filename: String)
   }
 
   override def getParents(atomIdSet: Set[String]): Set[String] =
-    memoizeSync(Some(2.seconds)) {
+    memoizeSync(cacheTimePeriod) {
       if (atomIdSet.isEmpty) return Set()
 
       val conn = db.createConnection()


### PR DESCRIPTION
This PR improves UMLS-RRF-Scala in two ways:
1. The Filler module now prepares the output as a LazyList, rather than mapping the entire list in one go.
2. It standardizes the cache time period to None (i.e. cache indefinitely), rather than the overly short two seconds we were using earlier.

It also fixes two minor bugs:
1. We were previously not reading the `--fill-predicate-id` command line option correctly: if it was surrounded by single quotes, those would be included as part of the predicate ID, so it wouldn't match correctly. This PR changes that behavior so that (1) comma-separated values are can be used to provide multiple predicate IDs, and (2) each predicate ID is checked to see if it has an initial and final single quote; if so, both are eliminated.
2. We were using `SSSOM:` prefixed CURIEs for some Fillers, while others used the full URI (`http://purl.org/sssom/type/`). This PR standardizes that so we only use the full URI.